### PR TITLE
QHA :: Addition of a function to write 'fitted' helmholtz_volume to gnuplot style file

### DIFF
--- a/phonopy/api_qha.py
+++ b/phonopy/api_qha.py
@@ -250,6 +250,9 @@ class PhonopyQHA(object):
     def write_helmholtz_volume(self, filename='helmholtz-volume.dat'):
         self._qha.write_helmholtz_volume(filename=filename)
 
+    def write_helmholtz_volume_fitted(self, thin_number, filename='helmholtz-volume_fitted.dat'):
+        self._qha.write_helmholtz_volume_fitted(thin_number, filename=filename)
+
     def write_volume_temperature(self, filename='volume-temperature.dat'):
         self._qha.write_volume_temperature(filename=filename)
 

--- a/scripts/phonopy-qha
+++ b/scripts/phonopy-qha
@@ -244,6 +244,7 @@ def main(args):
         phonopy_qha.plot_pdf_gruneisen_temperature()
 
     phonopy_qha.write_helmholtz_volume()
+    phonopy_qha.write_helmholtz_volume_fitted(thin_number = args.thin_number)
     phonopy_qha.write_volume_temperature()
     phonopy_qha.write_thermal_expansion()
     phonopy_qha.write_gibbs_temperature()


### PR DESCRIPTION
Dear @atztogo,

   Added a function to write 'fitted' helmholtzVsVolume to Gnuplot style file, similar to other *.dat files that are getting written out during a 'phonopy-qha' execution.

   This could be very handy to quickly make a graph somewhere else. I mean the first graph of the three shown in 'view mode (-p option)' of phonopy-qha utility.

   This would write **helmholtz-volume_fitted.dat** file in addition to the earlier helmholtz-volume.dat file.

   Best Regards
