### PR TITLE
Fix for fetching VASP version correctly.

### DIFF
--- a/phonopy/interface/vasp.py
+++ b/phonopy/interface/vasp.py
@@ -577,7 +577,7 @@ class Vasprun:
                 for element_i in element.findall("./i"):
                     if element_i.attrib["name"] == "version":
                         version_str = element_i.text.strip()
-                        version_nums = [int(v) for v in version_str.split(".")]
+                        version_nums = version_str.split('-')[0].split(".")
 
             if num_atom == 0:
                 atomtypes = self._get_atomtypes(element)
@@ -616,7 +616,7 @@ class Vasprun:
 
             # Recover the unit of eV/Angstrom^2 for VASP-6.
             if version_nums is not None and len(version_nums) > 1:
-                if version_nums[0] == 6 and version_nums[1] > 1:
+                if int(version_nums[0]) == 6 and int(version_nums[1]) > 1:
                     force_constants /= VaspToTHz**2
 
             return force_constants, elements

--- a/phonopy/interface/vasp.py
+++ b/phonopy/interface/vasp.py
@@ -577,7 +577,7 @@ class Vasprun:
                 for element_i in element.findall("./i"):
                     if element_i.attrib["name"] == "version":
                         version_str = element_i.text.strip()
-                        version_nums = version_str.split('-')[0].split(".")
+                        version_nums = version_str.split("-")[0].split(".")
 
             if num_atom == 0:
                 atomtypes = self._get_atomtypes(element)


### PR DESCRIPTION
For VASP version, one case had a line in vasprun.xml like: **5.4.4.18Apr17-6-g9f103f2a35**

This line had "-" as well as non integers, which clashes with [this line](https://github.com/phonopy/phonopy/blob/5953d7963dbdd7abdf20e5e6904f5098f6a49c40/phonopy/interface/vasp.py#L580).

and throws and error, **ValueError: invalid literal for int() with base 10: '18Apr17-6-g9f103f2a35'**

This PR fixes the issue above.

Thanks