### PR TITLE
Distribute fc2 prefering pure translation operations

### DIFF
--- a/c/_phonopy.c
+++ b/c/_phonopy.c
@@ -757,6 +757,7 @@ static PyObject* py_distribute_fc2(PyObject* self, PyObject* args) {
     PyArrayObject* py_map_atoms;
     PyArrayObject* py_map_syms;
     PyArrayObject* py_atom_list;
+    PyArrayObject* py_fc_indices_of_atom_list;
     PyArrayObject* py_rotations_cart;
 
     double(*r_carts)[3][3];
@@ -765,17 +766,19 @@ static PyObject* py_distribute_fc2(PyObject* self, PyObject* args) {
     int* map_atoms;
     int* map_syms;
     int* atom_list;
+    int* fc_indices_of_atom_list;
     npy_intp num_pos, num_rot, len_atom_list;
 
-    if (!PyArg_ParseTuple(args, "OOOOOO", &py_force_constants, &py_atom_list,
-                          &py_rotations_cart, &py_permutations, &py_map_atoms,
-                          &py_map_syms)) {
+    if (!PyArg_ParseTuple(args, "OOOOOOO", &py_force_constants, &py_atom_list,
+                          &py_fc_indices_of_atom_list, &py_rotations_cart,
+                          &py_permutations, &py_map_atoms, &py_map_syms)) {
         return NULL;
     }
 
     fc2 = (double(*)[3][3])PyArray_DATA(py_force_constants);
     atom_list = (int*)PyArray_DATA(py_atom_list);
     len_atom_list = PyArray_DIMS(py_atom_list)[0];
+    fc_indices_of_atom_list = (int*)PyArray_DATA(py_fc_indices_of_atom_list);
     permutations = (int*)PyArray_DATA(py_permutations);
     map_atoms = (int*)PyArray_DATA(py_map_atoms);
     map_syms = (int*)PyArray_DATA(py_map_syms);
@@ -801,8 +804,9 @@ static PyObject* py_distribute_fc2(PyObject* self, PyObject* args) {
         return NULL;
     }
 
-    phpy_distribute_fc2(fc2, atom_list, len_atom_list, r_carts, permutations,
-                        map_atoms, map_syms, num_rot, num_pos);
+    phpy_distribute_fc2(fc2, atom_list, len_atom_list, fc_indices_of_atom_list,
+                        r_carts, permutations, map_atoms, map_syms, num_rot,
+                        num_pos);
     Py_RETURN_NONE;
 }
 

--- a/c/phonopy.c
+++ b/c/phonopy.c
@@ -57,6 +57,7 @@ static double get_heat_capacity(const double temperature, const double f);
 /* static double get_energy(double temperature, double f); */
 static void distribute_fc2(double (*fc2)[3][3], const int *atom_list,
                            const int len_atom_list,
+                           const int *fc_indices_of_atom_list,
                            PHPYCONST double (*r_carts)[3][3],
                            const int *permutations, const int *map_atoms,
                            const int *map_syms, const int num_rot,
@@ -306,12 +307,14 @@ void phpy_get_thermal_properties(double *thermal_props,
 
 void phpy_distribute_fc2(double (*fc2)[3][3], const int *atom_list,
                          const int len_atom_list,
+                         const int *fc_indices_of_atom_list,
                          PHPYCONST double (*r_carts)[3][3],
                          const int *permutations, const int *map_atoms,
                          const int *map_syms, const int num_rot,
                          const int num_pos) {
-    distribute_fc2(fc2, atom_list, len_atom_list, r_carts, permutations,
-                   map_atoms, map_syms, num_rot, num_pos);
+    distribute_fc2(fc2, atom_list, len_atom_list, fc_indices_of_atom_list,
+                   r_carts, permutations, map_atoms, map_syms, num_rot,
+                   num_pos);
 }
 
 int phpy_compute_permutation(int *rot_atom, PHPYCONST double lat[3][3],
@@ -768,6 +771,7 @@ static double get_heat_capacity(const double temperature, const double f) {
 
 static void distribute_fc2(double (*fc2)[3][3], /* shape[n_pos][n_pos] */
                            const int *atom_list, const int len_atom_list,
+                           const int *fc_indices_of_atom_list,
                            PHPYCONST double (*r_carts)[3][3], /* shape[n_rot] */
                            const int *permutations, /* shape[n_rot][n_pos] */
                            const int *map_atoms,    /* shape [n_pos] */
@@ -810,9 +814,11 @@ static void distribute_fc2(double (*fc2)[3][3], /* shape[n_pos][n_pos] */
 
         /* distribute terms from atom_done to atom_todo */
         for (atom_other = 0; atom_other < num_pos; atom_other++) {
-            fc2_done = fc2[atom_list_reverse[atom_done] * num_pos +
-                           permutation[atom_other]];
-            fc2_todo = fc2[i * num_pos + atom_other];
+            fc2_done =
+                fc2[fc_indices_of_atom_list[atom_list_reverse[atom_done]] *
+                        num_pos +
+                    permutation[atom_other]];
+            fc2_todo = fc2[fc_indices_of_atom_list[i] * num_pos + atom_other];
             for (j = 0; j < 3; j++) {
                 for (k = 0; k < 3; k++) {
                     for (l = 0; l < 3; l++) {

--- a/c/phonopy.h
+++ b/c/phonopy.h
@@ -120,6 +120,7 @@ void phpy_get_thermal_properties(double *thermal_props,
                                  const double cutoff_frequency);
 void phpy_distribute_fc2(double (*fc2)[3][3], const int *atom_list,
                          const int len_atom_list,
+                         const int *fc_indices_of_atom_list,
                          PHPYCONST double (*r_carts)[3][3],
                          const int *permutations, const int *map_atoms,
                          const int *map_syms, const int num_rot,

--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -3397,6 +3397,7 @@ class Phonopy:
                     self._symmetry,
                     self._displacement_dataset,
                     atom_list=distributed_atom_list,
+                    primitive=self._primitive,
                     decimals=decimals,
                 )
 

--- a/phonopy/file_IO.py
+++ b/phonopy/file_IO.py
@@ -46,10 +46,10 @@ except ImportError:
     from yaml import Loader
 
 from phonopy.cui.settings import fracval
-from phonopy.harmonic.force_constants import similarity_transformation
 from phonopy.structure.atoms import PhonopyAtoms
 from phonopy.structure.dataset import get_displacements_and_forces
 from phonopy.structure.symmetry import Symmetry, elaborate_borns_and_epsilon
+from phonopy.utils import similarity_transformation
 
 
 #

--- a/phonopy/interface/wien2k.py
+++ b/phonopy/interface/wien2k.py
@@ -37,11 +37,11 @@ import sys
 
 import numpy as np
 
-from phonopy.harmonic.force_constants import similarity_transformation
 from phonopy.interface.vasp import check_forces, get_drift_forces
 from phonopy.structure.atoms import PhonopyAtoms as Atoms
 from phonopy.structure.cells import get_angles, get_cell_parameters
 from phonopy.structure.symmetry import Symmetry
+from phonopy.utils import similarity_transformation
 
 
 def parse_set_of_forces(

--- a/phonopy/phonon/group_velocity.py
+++ b/phonopy/phonon/group_velocity.py
@@ -40,10 +40,10 @@ import numpy as np
 
 from phonopy.harmonic.derivative_dynmat import DerivativeOfDynamicalMatrix
 from phonopy.harmonic.dynamical_matrix import DynamicalMatrix, DynamicalMatrixNAC
-from phonopy.harmonic.force_constants import similarity_transformation
 from phonopy.phonon.degeneracy import degenerate_sets
 from phonopy.structure.symmetry import Symmetry
 from phonopy.units import VaspToTHz
+from phonopy.utils import similarity_transformation
 
 
 class GroupVelocity:

--- a/phonopy/phonon/irreps.py
+++ b/phonopy/phonon/irreps.py
@@ -39,12 +39,12 @@ import numpy as np
 
 from phonopy.harmonic.derivative_dynmat import DerivativeOfDynamicalMatrix
 from phonopy.harmonic.dynamical_matrix import DynamicalMatrix, DynamicalMatrixNAC
-from phonopy.harmonic.force_constants import similarity_transformation
 from phonopy.phonon.character_table import character_table
 from phonopy.phonon.degeneracy import degenerate_sets as get_degenerate_sets
 from phonopy.structure.cells import is_primitive_cell
 from phonopy.structure.symmetry import Symmetry
 from phonopy.units import VaspToTHz
+from phonopy.utils import similarity_transformation
 
 
 class IrReps:

--- a/phonopy/structure/atoms.py
+++ b/phonopy/structure/atoms.py
@@ -1,5 +1,4 @@
 """PhonopyAtoms class and routines related to atoms."""
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011 Atsushi Togo
 # All rights reserved.
 #

--- a/phonopy/structure/grid_points.py
+++ b/phonopy/structure/grid_points.py
@@ -44,7 +44,6 @@ from spglib import (
     relocate_BZ_grid_address,
 )
 
-from phonopy.harmonic.force_constants import similarity_transformation
 from phonopy.structure.brillouin_zone import get_qpoints_in_Brillouin_zone
 from phonopy.structure.cells import (
     determinant,
@@ -58,6 +57,7 @@ from phonopy.structure.symmetry import (
     get_lattice_vector_equivalence,
     get_pointgroup_operations,
 )
+from phonopy.utils import similarity_transformation
 from phonopy.version import __version__
 
 

--- a/phonopy/structure/symmetry.py
+++ b/phonopy/structure/symmetry.py
@@ -38,13 +38,13 @@ import warnings
 import numpy as np
 import spglib
 
-from phonopy.harmonic.force_constants import similarity_transformation
 from phonopy.structure.atoms import PhonopyAtoms
 from phonopy.structure.cells import (
     compute_all_sg_permutations,
     get_primitive,
     get_supercell,
 )
+from phonopy.utils import similarity_transformation
 
 
 class Symmetry:

--- a/phonopy/utils.py
+++ b/phonopy/utils.py
@@ -1,0 +1,41 @@
+"""Utility functions."""
+# Copyright (C) 2022 Atsushi Togo
+# All rights reserved.
+#
+# This file is part of phonopy.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+#
+# * Neither the name of the phonopy project nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+
+
+def similarity_transformation(rot, mat):
+    """Similarity transformation by R x M x R^-1."""
+    return np.dot(rot, np.dot(mat, np.linalg.inv(rot)))


### PR DESCRIPTION
Function of similarity_transformation in force_constants.py was moved to phonopy/utils.py to avoid cirtular import.