### PR TITLE
Use libphpy when PHONOPY_USE_OPENMP=true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,49 @@ message(STATUS "CMAKE_SYSTEM_PREFIX_PATH: ${CMAKE_SYSTEM_PREFIX_PATH}")
 include(GNUInstallDirs)
 # set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Version numbers
+file(READ ${PROJECT_SOURCE_DIR}/phonopy/version.py version_file)
+string(REGEX MATCH "__version__.*([0-9]+)[.]([0-9]+)[.]([0-9]+)" phono3py_version ${version_file})
+set(phonopy_major_version ${CMAKE_MATCH_1})
+set(phonopy_minor_version ${CMAKE_MATCH_2})
+set(phonopy_micro_version ${CMAKE_MATCH_3})
+set(serial "${phonopy_major_version}.${phonopy_minor_version}.${phonopy_micro_version}")
+set(soserial "1")
+
 find_package(OpenMP)
 if (OpenMP_FOUND)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     message(STATUS "OpenMP libs: ${OpenMP_C_LIBRARIES}")
     message(STATUS "OpenMP flags: ${OpenMP_C_FLAGS}")
+endif()
+
+if (PHONOPY)
+  set(SOURCES_PHONO3PY
+    ${PROJECT_SOURCE_DIR}/c/phonopy.c
+    ${PROJECT_SOURCE_DIR}/c/dynmat.c
+    ${PROJECT_SOURCE_DIR}/c/derivative_dynmat.c
+    ${PROJECT_SOURCE_DIR}/c/rgrid.c
+    ${PROJECT_SOURCE_DIR}/c/tetrahedron_method.c)
+
+  if (BUILD_SHARED_LIBRARIES)
+  # Shared library
+    add_library(phpy SHARED ${SOURCES_PHONOPY})
+    target_link_libraries(phpy m ${OpenMP_C_LIBRARIES})
+    target_include_directories(phpy PRIVATE ${MY_INCLUDES})
+    set_property(TARGET phpy PROPERTY VERSION ${serial})
+    set_property(TARGET phpy PROPERTY SOVERSION ${soserial})
+    install(TARGETS phpy LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  endif()
+
+  # Static link library
+  add_library(phpy_static STATIC ${SOURCES_PHONO3PY})
+  target_link_libraries(phpy_static m ${OpenMP_C_LIBRARIES})
+  target_include_directories(phpy_static PRIVATE ${MY_INCLUDES})
+  set_property(TARGET phpy_static PROPERTY VERSION ${serial})
+  set_property(TARGET phpy_static PROPERTY SOVERSION ${soserial})
+  set_property(TARGET phpy_static PROPERTY OUTPUT_NAME phpy)
+  install(TARGETS phpy_static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  # Header file
+  install(FILES ${PROJECT_SOURCE_DIR}/c/phonopy.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()


### PR DESCRIPTION
`_OPENMP` is not activated when compiling via setuptools at least on M1 mac with conda-forge c-compiler. It was confirmed that compiling it by cmake and making static link library activates `_OPENMP` automatically. Therefore when `PHONOPY_USE_OPENMP=true`, the static link library is linked in setuptools. Otherwise, the compilation is done in a usual way.