### PR TITLE
GitHub action for openmp version

### DIFF
--- a/.github/workflows/phonopy-pytest-conda-openmp.yml
+++ b/.github/workflows/phonopy-pytest-conda-openmp.yml
@@ -5,33 +5,38 @@ on: [push]
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
         python-version: ${{ matrix.python-version }}
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
+        conda activate test
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
         conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest cmake
     - name: Install cp2k-input-tools
       run: |
+        conda activate test
         pip install cp2k-input-tools
     - name: Setup phonopy
       run: |
+        conda activate test
         export PHONOPY_USE_OPENMP=true
         pip install -e . -vvv
     - name: Test with pytest
       run: |
+        conda activate test
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/phonopy-pytest-conda-openmp.yml
+++ b/.github/workflows/phonopy-pytest-conda-openmp.yml
@@ -1,4 +1,4 @@
-name: phonopy test using conda-forge environment
+name: phonopy test using conda-forge environment with openmp
 
 on: [push]
 
@@ -22,12 +22,13 @@ jobs:
     - name: Install dependencies
       run: |
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
-        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest
+        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest cmake
     - name: Install cp2k-input-tools
       run: |
         pip install cp2k-input-tools
     - name: Setup phonopy
       run: |
+        export PHONOPY_USE_OPENMP=true
         pip install -e . -vvv
     - name: Test with pytest
       run: |

--- a/.github/workflows/phonopy-pytest-conda.yml
+++ b/.github/workflows/phonopy-pytest-conda.yml
@@ -5,32 +5,37 @@ on: [push]
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
         python-version: ${{ matrix.python-version }}
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
+        conda activate test
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
         conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest
     - name: Install cp2k-input-tools
       run: |
+        conda activate test
         pip install cp2k-input-tools
     - name: Setup phonopy
       run: |
+        conda activate test
         pip install -e . -vvv
     - name: Test with pytest
       run: |
+        conda activate test
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/c/phonopy.c
+++ b/c/phonopy.c
@@ -661,7 +661,7 @@ void phpy_set_index_permutation_symmetry_compact_fc(
     done = NULL;
 }
 
-long phpy_use_openmp() {
+long phpy_use_openmp(void) {
 #ifdef _OPENMP
     return 1;
 #else

--- a/c/phonopy.h
+++ b/c/phonopy.h
@@ -144,5 +144,5 @@ void phpy_set_index_permutation_symmetry_compact_fc(
     double *fc, const int p2s[], const int s2pp[], const int nsym_list[],
     const int perms[], const int n_satom, const int n_patom,
     const int is_transpose);
-long phpy_use_openmp();
+long phpy_use_openmp(void);
 #endif


### PR DESCRIPTION
Use conda environment from conda-incubator/setup-miniconda instead of github default one. This is probably necessary to activate environment variables installed with `c-compiler` package that is probably loaded when `conda activate test`.