### PR TITLE
dynmat, eigvec etc as double(*)[2]

### DIFF
--- a/c/_phonopy.c
+++ b/c/_phonopy.c
@@ -193,7 +193,7 @@ static PyObject* py_transform_dynmat_to_fc(PyObject* self, PyObject* args) {
     long use_openmp;
 
     double* fc;
-    double* dm;
+    double(*dm)[2];
     double(*comm_points)[3];
     double(*svecs)[3];
     double* masses;
@@ -211,7 +211,7 @@ static PyObject* py_transform_dynmat_to_fc(PyObject* self, PyObject* args) {
     }
 
     fc = (double*)PyArray_DATA(py_force_constants);
-    dm = (double*)PyArray_DATA(py_dynamical_matrices);
+    dm = (double(*)[2])PyArray_DATA(py_dynamical_matrices);
     comm_points = (double(*)[3])PyArray_DATA(py_commensurate_points);
     svecs = (double(*)[3])PyArray_DATA(py_svecs);
     masses = (double*)PyArray_DATA(py_masses);
@@ -454,7 +454,7 @@ static PyObject* py_get_dynamical_matrix(PyObject* self, PyObject* args) {
     PyArrayObject* py_p2s_map;
     long use_openmp;
 
-    double* dm;
+    double(*dm)[2];
     double* fc;
     double* q;
     double(*svecs)[3];
@@ -471,7 +471,7 @@ static PyObject* py_get_dynamical_matrix(PyObject* self, PyObject* args) {
         return NULL;
     }
 
-    dm = (double*)PyArray_DATA(py_dynamical_matrix);
+    dm = (double(*)[2])PyArray_DATA(py_dynamical_matrix);
     fc = (double*)PyArray_DATA(py_force_constants);
     q = (double*)PyArray_DATA(py_q);
     svecs = (double(*)[3])PyArray_DATA(py_svecs);
@@ -503,7 +503,7 @@ static PyObject* py_get_nac_dynamical_matrix(PyObject* self, PyObject* args) {
     double factor;
     long use_openmp;
 
-    double* dm;
+    double(*dm)[2];
     double* fc;
     double* q_cart;
     double* q;
@@ -525,7 +525,7 @@ static PyObject* py_get_nac_dynamical_matrix(PyObject* self, PyObject* args) {
                           &py_born, &factor, &use_openmp))
         return NULL;
 
-    dm = (double*)PyArray_DATA(py_dynamical_matrix);
+    dm = (double(*)[2])PyArray_DATA(py_dynamical_matrix);
     fc = (double*)PyArray_DATA(py_force_constants);
     q_cart = (double*)PyArray_DATA(py_q_cart);
     q = (double*)PyArray_DATA(py_q);
@@ -566,8 +566,8 @@ static PyObject* py_get_recip_dipole_dipole(PyObject* self, PyObject* args) {
     double tolerance;
     long use_openmp;
 
-    double* dd;
-    double* dd_q0;
+    double(*dd)[2];
+    double(*dd_q0)[2];
     double(*G_list)[3];
     double* q_vector;
     double* q_direction;
@@ -582,8 +582,8 @@ static PyObject* py_get_recip_dipole_dipole(PyObject* self, PyObject* args) {
                           &use_openmp))
         return NULL;
 
-    dd = (double*)PyArray_DATA(py_dd);
-    dd_q0 = (double*)PyArray_DATA(py_dd_q0);
+    dd = (double(*)[2])PyArray_DATA(py_dd);
+    dd_q0 = (double(*)[2])PyArray_DATA(py_dd_q0);
     G_list = (double(*)[3])PyArray_DATA(py_G_list);
     if ((PyObject*)py_q_direction == Py_None) {
         q_direction = NULL;
@@ -619,7 +619,7 @@ static PyObject* py_get_recip_dipole_dipole_q0(PyObject* self, PyObject* args) {
     double tolerance;
     long use_openmp;
 
-    double* dd_q0;
+    double(*dd_q0)[2];
     double(*G_list)[3];
     double(*born)[3][3];
     double(*dielectric)[3];
@@ -631,7 +631,7 @@ static PyObject* py_get_recip_dipole_dipole_q0(PyObject* self, PyObject* args) {
                           &use_openmp))
         return NULL;
 
-    dd_q0 = (double*)PyArray_DATA(py_dd_q0);
+    dd_q0 = (double(*)[2])PyArray_DATA(py_dd_q0);
     G_list = (double(*)[3])PyArray_DATA(py_G_list);
     born = (double(*)[3][3])PyArray_DATA(py_born);
     dielectric = (double(*)[3])PyArray_DATA(py_dielectric);
@@ -665,7 +665,7 @@ static PyObject* py_get_derivative_dynmat(PyObject* self, PyObject* args) {
     double nac_factor;
     long use_openmp;
 
-    double* ddm;
+    double(*ddm)[2];
     double* fc;
     double* q_vector;
     double* lat;
@@ -690,7 +690,7 @@ static PyObject* py_get_derivative_dynmat(PyObject* self, PyObject* args) {
         return NULL;
     }
 
-    ddm = (double*)PyArray_DATA(py_derivative_dynmat);
+    ddm = (double(*)[2])PyArray_DATA(py_derivative_dynmat);
     fc = (double*)PyArray_DATA(py_force_constants);
     q_vector = (double*)PyArray_DATA(py_q_vector);
     lat = (double*)PyArray_DATA(py_lattice);

--- a/c/derivative_dynmat.c
+++ b/c/derivative_dynmat.c
@@ -39,10 +39,10 @@
 #define PI 3.14159265358979323846
 
 static void get_derivative_dynmat_at_q(
-    double *derivative_dynmat, const long i, const long j, const double *ddnac,
-    const double *dnac, const long is_nac, const long num_patom,
-    const long num_satom, const double *fc, const double *q,
-    const double *lattice, /* column vector */
+    double (*derivative_dynmat)[2], const long i, const long j,
+    const double *ddnac, const double *dnac, const long is_nac,
+    const long num_patom, const long num_satom, const double *fc,
+    const double *q, const double *lattice, /* column vector */
     const double (*svecs)[3], const long (*multi)[2], const double *mass,
     const long *s2p_map, const long *p2s_map, const double nac_factor,
     const double *born, const double *dielectric, const double *q_direction);
@@ -60,7 +60,7 @@ static double get_dC(const long cart_i, const long cart_j, const long cart_k,
                      const double q[3], const double *dielectric);
 
 void ddm_get_derivative_dynmat_at_q(
-    double *derivative_dynmat, const long num_patom, const long num_satom,
+    double (*derivative_dynmat)[2], const long num_patom, const long num_satom,
     const double *fc, const double *q,
     const double *lattice, /* column vector */
     const double (*svecs)[3], const long (*multi)[2], const double *mass,
@@ -122,16 +122,14 @@ void ddm_get_derivative_dynmat_at_q(
     for (i = 0; i < 3; i++) {
         for (j = i; j < num_patom * 3; j++) {
             for (k = 0; k < num_patom * 3; k++) {
-                adrs =
-                    i * num_patom * num_patom * 18 + j * num_patom * 6 + k * 2;
-                adrsT =
-                    i * num_patom * num_patom * 18 + k * num_patom * 6 + j * 2;
-                derivative_dynmat[adrs] += derivative_dynmat[adrsT];
-                derivative_dynmat[adrs] /= 2;
-                derivative_dynmat[adrs + 1] -= derivative_dynmat[adrsT + 1];
-                derivative_dynmat[adrs + 1] /= 2;
-                derivative_dynmat[adrsT] = derivative_dynmat[adrs];
-                derivative_dynmat[adrsT + 1] = -derivative_dynmat[adrs + 1];
+                adrs = i * num_patom * num_patom * 9 + j * num_patom * 3 + k;
+                adrsT = i * num_patom * num_patom * 9 + k * num_patom * 3 + j;
+                derivative_dynmat[adrs][0] += derivative_dynmat[adrsT][0];
+                derivative_dynmat[adrs][0] /= 2;
+                derivative_dynmat[adrs][1] -= derivative_dynmat[adrsT][1];
+                derivative_dynmat[adrs][1] /= 2;
+                derivative_dynmat[adrsT][0] = derivative_dynmat[adrs][0];
+                derivative_dynmat[adrsT][1] = -derivative_dynmat[adrs][1];
             }
         }
     }
@@ -145,10 +143,10 @@ void ddm_get_derivative_dynmat_at_q(
 }
 
 void get_derivative_dynmat_at_q(
-    double *derivative_dynmat, const long i, const long j, const double *ddnac,
-    const double *dnac, const long is_nac, const long num_patom,
-    const long num_satom, const double *fc, const double *q,
-    const double *lattice, /* column vector */
+    double (*derivative_dynmat)[2], const long i, const long j,
+    const double *ddnac, const double *dnac, const long is_nac,
+    const long num_patom, const long num_satom, const double *fc,
+    const double *q, const double *lattice, /* column vector */
     const double (*svecs)[3], const long (*multi)[2], const double *mass,
     const long *s2p_map, const long *p2s_map, const double nac_factor,
     const double *born, const double *dielectric, const double *q_direction) {
@@ -243,10 +241,10 @@ void get_derivative_dynmat_at_q(
     for (k = 0; k < 3; k++) {
         for (l = 0; l < 3; l++) {
             for (m = 0; m < 3; m++) {
-                adrs = (k * num_patom * num_patom * 18 +
-                        (i * 3 + l) * num_patom * 6 + j * 6 + m * 2);
-                derivative_dynmat[adrs] += ddm_real[k][l][m];
-                derivative_dynmat[adrs + 1] += ddm_imag[k][l][m];
+                adrs = (k * num_patom * num_patom * 9 +
+                        (i * 3 + l) * num_patom * 3 + j * 3 + m * 1);
+                derivative_dynmat[adrs][0] += ddm_real[k][l][m];
+                derivative_dynmat[adrs][1] += ddm_imag[k][l][m];
             }
         }
     }

--- a/c/derivative_dynmat.h
+++ b/c/derivative_dynmat.h
@@ -36,7 +36,7 @@
 #define __derivative_dynmat_H__
 
 void ddm_get_derivative_dynmat_at_q(
-    double *derivative_dynmat, const long num_patom, const long num_satom,
+    double (*derivative_dynmat)[2], const long num_patom, const long num_satom,
     const double *fc, const double *q,
     const double *lattice, /* column vector */
     const double (*svecs)[3], const long (*multi)[2], const double *mass,

--- a/c/dynmat.h
+++ b/c/dynmat.h
@@ -35,7 +35,7 @@
 #ifndef __dynmat_H__
 #define __dynmat_H__
 
-long dym_get_dynamical_matrix_at_q(double *dynamical_matrix,
+long dym_get_dynamical_matrix_at_q(double (*dynamical_matrix)[2],
                                    const long num_patom, const long num_satom,
                                    const double *fc, const double q[3],
                                    const double (*svecs)[3],
@@ -44,8 +44,8 @@ long dym_get_dynamical_matrix_at_q(double *dynamical_matrix,
                                    const double (*charge_sum)[3][3],
                                    const long use_openmp);
 void dym_get_recip_dipole_dipole(
-    double *dd,                /* [natom, 3, natom, 3, (real,imag)] */
-    const double *dd_q0,       /* [natom, 3, 3, (real,imag)] */
+    double (*dd)[2],           /* [natom, 3, natom, 3, (real,imag)] */
+    const double (*dd_q0)[2],  /* [natom, 3, 3, (real,imag)] */
     const double (*G_list)[3], /* [num_G, 3] */
     const long num_G, const long num_patom, const double q_cart[3],
     const double *q_direction_cart, /* must be pointer */
@@ -54,7 +54,7 @@ void dym_get_recip_dipole_dipole(
     const double factor,    /* 4pi/V*unit-conv */
     const double lambda, const double tolerance, const long use_openmp);
 void dym_get_recip_dipole_dipole_q0(
-    double *dd_q0,             /* [natom, 3, 3, (real,imag)] */
+    double (*dd_q0)[2],        /* [natom, 3, 3, (real,imag)] */
     const double (*G_list)[3], /* [num_G, 3] */
     const long num_G, const long num_patom, const double (*born)[3][3],
     const double dielectric[3][3], const double (*pos)[3], /* [natom, 3] */
@@ -67,7 +67,7 @@ void dym_get_charge_sum(double (*charge_sum)[3][3], const long num_patom,
 /* comm_points[num_satom / num_patom, 3] */
 /* shortest_vectors[:, 3] */
 /* multiplicities[num_satom, num_patom, 2] */
-void dym_transform_dynmat_to_fc(double *fc, const double *dm,
+void dym_transform_dynmat_to_fc(double *fc, const double (*dm)[2],
                                 const double (*comm_points)[3],
                                 const double (*svecs)[3],
                                 const long (*multi)[2], const double *masses,

--- a/c/phonopy.c
+++ b/c/phonopy.c
@@ -64,7 +64,7 @@ static void distribute_fc2(double (*fc2)[3][3], const int *atom_list,
                            const int num_pos);
 static int nint(const double a);
 
-void phpy_transform_dynmat_to_fc(double *fc, const double *dm,
+void phpy_transform_dynmat_to_fc(double *fc, const double (*dm)[2],
                                  const double (*comm_points)[3],
                                  const double (*svecs)[3],
                                  const long (*multi)[2], const double *masses,
@@ -76,7 +76,7 @@ void phpy_transform_dynmat_to_fc(double *fc, const double *dm,
                                use_openmp);
 }
 
-long phpy_get_dynamical_matrix_at_q(double *dynamical_matrix,
+long phpy_get_dynamical_matrix_at_q(double (*dynamical_matrix)[2],
                                     const long num_patom, const long num_satom,
                                     const double *fc, const double q[3],
                                     const double (*svecs)[3],
@@ -97,8 +97,8 @@ void phpy_get_charge_sum(
 }
 
 void phpy_get_recip_dipole_dipole(
-    double *dd,                /* [natom, 3, natom, 3, (real,imag)] */
-    const double *dd_q0,       /* [natom, 3, 3, (real,imag)] */
+    double (*dd)[2],           /* [natom, 3, natom, 3, (real,imag)] */
+    const double (*dd_q0)[2],  /* [natom, 3, 3, (real,imag)] */
     const double (*G_list)[3], /* [num_G, 3] */
     const long num_G, const long num_patom, const double q_cart[3],
     const double *q_direction_cart, /* must be pointer */
@@ -112,7 +112,7 @@ void phpy_get_recip_dipole_dipole(
 }
 
 void phpy_get_recip_dipole_dipole_q0(
-    double *dd_q0,             /* [natom, 3, 3, (real,imag)] */
+    double (*dd_q0)[2],        /* [natom, 3, 3, (real,imag)] */
     const double (*G_list)[3], /* [num_G, 3] */
     const long num_G, const long num_patom, const double (*born)[3][3],
     const double dielectric[3][3], const double (*pos)[3], /* [num_patom, 3] */
@@ -123,7 +123,7 @@ void phpy_get_recip_dipole_dipole_q0(
 }
 
 void phpy_get_derivative_dynmat_at_q(
-    double *derivative_dynmat, const long num_patom, const long num_satom,
+    double (*derivative_dynmat)[2], const long num_patom, const long num_satom,
     const double *fc, const double *q,
     const double *lattice, /* column vector */
     const double (*svecs)[3], const long (*multi)[2], const double *mass,

--- a/c/phonopy.h
+++ b/c/phonopy.h
@@ -37,14 +37,14 @@
 #ifndef __phonopy_H__
 #define __phonopy_H__
 
-void phpy_transform_dynmat_to_fc(double *fc, const double *dm,
+void phpy_transform_dynmat_to_fc(double *fc, const double (*dm)[2],
                                  const double (*comm_points)[3],
                                  const double (*svecs)[3],
                                  const long (*multi)[2], const double *masses,
                                  const long *s2pp_map, const long *fc_index_map,
                                  const long num_patom,
                                  const long num_satomconst, long use_openmp);
-long phpy_get_dynamical_matrix_at_q(double *dynamical_matrix,
+long phpy_get_dynamical_matrix_at_q(double (*dynamical_matrix)[2],
                                     const long num_patom, const long num_satom,
                                     const double *fc, const double q[3],
                                     const double (*svecs)[3],
@@ -57,8 +57,8 @@ void phpy_get_charge_sum(
     const double factor, /* 4pi/V*unit-conv and denominator */
     const double q_cart[3], const double (*born)[3][3]);
 void phpy_get_recip_dipole_dipole(
-    double *dd,                /* [natom, 3, natom, 3, (real,imag)] */
-    const double *dd_q0,       /* [natom, 3, 3, (real,imag)] */
+    double (*dd)[2],           /* [natom, 3, natom, 3, (real,imag)] */
+    const double (*dd_q0)[2],  /* [natom, 3, 3, (real,imag)] */
     const double (*G_list)[3], /* [num_G, 3] */
     const long num_G, const long num_patom, const double q_cart[3],
     const double *q_direction_cart, /* must be pointer */
@@ -67,13 +67,13 @@ void phpy_get_recip_dipole_dipole(
     const double factor,    /* 4pi/V*unit-conv */
     const double lambda, const double tolerance, const long use_openmp);
 void phpy_get_recip_dipole_dipole_q0(
-    double *dd_q0,             /* [natom, 3, 3, (real,imag)] */
+    double (*dd_q0)[2],        /* [natom, 3, 3, (real,imag)] */
     const double (*G_list)[3], /* [num_G, 3] */
     const long num_G, const long num_patom, const double (*born)[3][3],
     const double dielectric[3][3], const double (*pos)[3], /* [num_patom, 3] */
     const double lambda, const double tolerance, const long use_openmp);
 void phpy_get_derivative_dynmat_at_q(
-    double *derivative_dynmat, const long num_patom, const long num_satom,
+    double (*derivative_dynmat)[2], const long num_patom, const long num_satom,
     const double *fc, const double *q,
     const double *lattice, /* column vector */
     const double (*svecs)[3], const long (*multi)[2], const double *mass,


### PR DESCRIPTION
From `*eigvecs` to `(*eigvecs)[2]` to represent complex number. This is a little bit more explicit than before.