### PR TITLE
Deprecate --temperature option

### DIFF
--- a/phonopy/cui/phonopy_argparse.py
+++ b/phonopy/cui/phonopy_argparse.py
@@ -696,12 +696,19 @@ def get_parser(
     )
     parser.add_argument(
         "--rd-temperature",
-        "--temperature",
         dest="rd_temperature",
         type=float,
         default=None,
         metavar="TEMPERATURE",
         help="A temperature used to generate random displacements.",
+    )
+    parser.add_argument(
+        "--temperature",
+        dest="temperature",
+        type=float,
+        default=None,
+        metavar="TEMPERATURE",
+        help="(Deprecated) A temperature used to generate random displacements.",
     )
     parser.add_argument(
         "--readfc",

--- a/phonopy/cui/phonopy_script.py
+++ b/phonopy/cui/phonopy_script.py
@@ -81,7 +81,7 @@ from phonopy.structure.dataset import forces_in_dataset
 from phonopy.units import THzToEv
 
 
-# AA is created at http://www.network-science.de/ascii/.
+# AA is created at http://www.network-science.de/ascii/ with standard.
 def print_phonopy():
     """Show phonopy logo."""
     print(
@@ -140,6 +140,19 @@ def print_error():
  / _ \ '__| '__/ _ \| '__|
 |  __/ |  | | | (_) | |
  \___|_|  |_|  \___/|_|
+"""
+    )
+
+
+def print_warning():
+    """Show warning banner."""
+    print(
+        r"""                          _
+__      ____ _ _ __ _ __ (_)_ __   __ _
+\ \ /\ / / _` | '__| '_ \| | '_ \ / _` |
+ \ V  V / (_| | |  | | | | | | | | (_| |
+  \_/\_/ \__,_|_|  |_| |_|_|_| |_|\__, |
+                                  |___/
 """
     )
 
@@ -1889,6 +1902,7 @@ def main(**argparse_control):
             number_of_snapshots=settings.random_displacements,
             random_seed=settings.random_seed,
             temperature=settings.random_displacement_temperature,
+            cutoff_frequency=settings.cutoff_frequency,
         )
         write_displacements_files_then_exit(
             phonon, settings, confs, cell_info["optional_structure_info"], log_level

--- a/phonopy/cui/settings.py
+++ b/phonopy/cui/settings.py
@@ -602,16 +602,6 @@ class ConfParser:
                 symtol = self._args.symmetry_tolerance
                 self._confs["symmetry_tolerance"] = symtol
 
-        if "rd_temperature" in arg_list:
-            if self._args.rd_temperature is not None:
-                self._confs[
-                    "random_displacement_temperature"
-                ] = self._args.rd_temperature
-
-        if "temperatures" in arg_list:
-            if self._args.temperatures is not None:
-                self._confs["temperatures"] = " ".join(self._args.temperatures)
-
         if "tmax" in arg_list:
             if self._args.tmax:
                 self._confs["tmax"] = self._args.tmax
@@ -900,10 +890,6 @@ class ConfParser:
                     self.setting_error("Temperatures are incorrectly set.")
                 else:
                     self.set_parameter("temperatures", vals)
-
-            if conf_key == "random_displacement_temperature":
-                val = confs["random_displacement_temperature"]
-                self.set_parameter("random_displacement_temperature", float(val))
 
             if conf_key == "tmin":
                 val = float(confs["tmin"])
@@ -1666,6 +1652,26 @@ class PhonopyConfParser(ConfParser):
             if nrand:
                 self._confs["random_displacements"] = nrand
 
+        if "rd_temperature" in arg_list:
+            if self._args.rd_temperature is not None:
+                self._confs[
+                    "random_displacement_temperature"
+                ] = self._args.rd_temperature
+
+        if "temperature" in arg_list:
+            if self._args.temperature is not None:
+                print(
+                    "*****************************************************************"
+                )
+                print(
+                    "--temperature option is deprecated. Use --rd-temperature instead."
+                )
+                print(
+                    "*****************************************************************"
+                )
+                print()
+                self._confs["random_displacement_temperature"] = self._args.temperature
+
         if "random_seed" in arg_list:
             if self._args.random_seed:
                 seed = self._args.random_seed
@@ -2005,6 +2011,10 @@ class PhonopyConfParser(ConfParser):
                 self.set_parameter(
                     "random_displacements", int(confs["random_displacements"])
                 )
+
+            if conf_key == "random_displacement_temperature":
+                val = confs["random_displacement_temperature"]
+                self.set_parameter("random_displacement_temperature", float(val))
 
             if conf_key == "random_seed":
                 self.set_parameter("random_seed", int(confs["random_seed"]))


### PR DESCRIPTION
Random displacements at finite temperature will be documented at the next release v2.17. The option `--temperature` is replaced by `--rd-temperature`. It is made to display warning when `--temperature` option is invoked.