### PR TITLE
Fourier interpolation of force constants

### DIFF
--- a/phonopy/cui/phonopy_script.py
+++ b/phonopy/cui/phonopy_script.py
@@ -495,7 +495,7 @@ def create_FORCE_SETS_from_settings(settings, cell_filename, symprec, log_level)
 def produce_force_constants(
     phonon: Phonopy, settings, phpy_yaml, unitcell_filename, log_level
 ):
-    """Run force constants calculation."""
+    """Run force constants calculation (non-phonopy-yaml mode)."""
     num_satom = len(phonon.supercell)
     is_full_fc = settings.fc_spg_symmetry or settings.is_full_fc
 
@@ -618,32 +618,37 @@ def _read_force_constants_from_file(
         fc = parse_FORCE_CONSTANTS(filename="FORCE_CONSTANTS", p2s_map=p2s_map)
         fc_filename = "FORCE_CONSTANTS"
 
+    if log_level:
+        print('Force constants are read from "%s".' % fc_filename)
+
+    if fc.shape[1] != num_satom:
+        error_text = "\n".join(
+            [
+                f"Number of atoms in supercell ({num_satom}) is not consistent with "
+                "the matrix shape of ",
+                f"force constants {fc.shape[:2]} read from ",
+            ]
+        )
+        if settings.is_hdf5 or settings.readfc_format == "hdf5":
+            error_text += "force_constants.hdf5.\n"
+        else:
+            error_text += "FORCE_CONSTANTS.\n"
+        error_text += (
+            "Please carefully check DIM, FORCE_CONSTANTS, " "and %s."
+        ) % unitcell_filename
+        print_error_message(error_text)
         if log_level:
-            print('Force constants are read from "%s".' % fc_filename)
+            print_error()
+        sys.exit(1)
 
-        if fc.shape[1] != num_satom:
-            error_text = (
-                "Number of atoms in supercell is not consistent "
-                "with the matrix shape of\nforce constants read "
-                "from "
-            )
-            if settings.is_hdf5 or settings.readfc_format == "hdf5":
-                error_text += "force_constants.hdf5.\n"
-            else:
-                error_text += "FORCE_CONSTANTS.\n"
-            error_text += (
-                "Please carefully check DIM, FORCE_CONSTANTS, " "and %s."
-            ) % unitcell_filename
-            print_error_message(error_text)
-            if log_level:
-                print_error()
-            sys.exit(1)
+    # Compact fc is expanded to full fc when full fc is required.
+    if is_full_fc and fc.shape[0] != fc.shape[1]:
+        fc = compact_fc_to_full_fc(phonon, fc, log_level=log_level)
+    elif not is_full_fc and fc.shape[0] == fc.shape[1]:
+        fc = full_fc_to_compact_fc(phonon, fc, log_level=log_level)
 
-        # Compact fc is expanded to full fc when full fc is required.
-        if is_full_fc and fc.shape[0] != fc.shape[1]:
-            fc = compact_fc_to_full_fc(phonon, fc, log_level=log_level)
-        elif not is_full_fc and fc.shape[0] == fc.shape[1]:
-            fc = full_fc_to_compact_fc(phonon, fc, log_level=log_level)
+    if log_level:
+        print(f"Array shape of force constants: {fc.shape}")
 
     phonon.force_constants = fc
 

--- a/phonopy/harmonic/dynamical_matrix.py
+++ b/phonopy/harmonic/dynamical_matrix.py
@@ -627,6 +627,21 @@ class DynamicalMatrixGL(DynamicalMatrixNAC):
             self._Lambda,
         )
 
+    @property
+    def short_range_force_constants(self):
+        """Getter and setter of short-range force constants.
+
+        Initial short range force constants are computed at
+        make_Gonze_nac_dataset.
+
+        """
+        return self._Gonze_force_constants
+
+    @short_range_force_constants.setter
+    def short_range_force_constants(self, short_range_force_constants):
+        """Set short-range force constants."""
+        self._Gonze_force_constants = short_range_force_constants
+
     def get_Gonze_nac_dataset(self):
         """Return Gonze-Lee NAC dataset."""
         warnings.warn(

--- a/phonopy/harmonic/dynmat_to_fc.py
+++ b/phonopy/harmonic/dynmat_to_fc.py
@@ -135,16 +135,18 @@ def categorize_commensurate_points(comm_points):
     return ii, ij
 
 
-def ph2fc(ph_orig: "Phonopy", supercell_matrix):
+def ph2fc(ph_orig: "Phonopy", supercell_matrix, with_nac=True):
     """Transform force constants in Phonopy instance to other shape.
 
-    For example, ph_orig.supercell_matrix is np.diag([2, 2, 2]) and
-    supercell_matrix is np.diag([4, 4, 4]), force constants having the
-    later shape are returned. This is considered useful when ph_orig
-    has non-analytical correction (NAC). The effect of this correction
-    is included in the returned force constants. Phonons before and after
-    this operation at commensurate points of the later supercell_matrix
-    should agree.
+    This function is deprecated. Use ph2ph or Phonopy.ph2ph.
+
+    Parameters
+    ----------
+    supercell_matrix : array_like
+        This specifies array shape of the force constants.
+    with_nac : bool, optional
+        Use non-analytical term correction if NAC paramerters exist. Default is
+        True.
 
     Returns
     -------
@@ -152,7 +154,32 @@ def ph2fc(ph_orig: "Phonopy", supercell_matrix):
         Transformed force constants of ``supercell_matrix``.
 
     """
-    return ph_orig.ph2ph(supercell_matrix).force_constants
+    warnings.warn(
+        "ph2fc function is deprecated. Use Phonopy.ph2ph instead.", DeprecationWarning
+    )
+    return ph2ph(ph_orig, supercell_matrix, with_nac=with_nac).force_constants
+
+
+def ph2ph(ph_orig: "Phonopy", supercell_matrix, with_nac=False) -> "Phonopy":
+    """Transform force constants in Phonopy instance to other shape.
+
+    Parameters
+    ----------
+    supercell_matrix : array_like
+        This specifies array shape of the force constants.
+    with_nac : bool, optional
+        Non-analytical term correction (NAC) is used under the Fourier
+        interpolation and NAC parameters are copied to Phonopy class
+        instance if they exist. Default is False.
+
+    Returns
+    -------
+    ph : Phonopy
+        Phonopy class instance with init parameters of this Phonopy class
+        instance and transformed force constants of `supercell_matrix`.
+
+    """
+    return ph_orig.ph2ph(supercell_matrix, with_nac=with_nac)
 
 
 class DynmatToForceConstants:

--- a/test/harmonic/test_dynmat_to_fc.py
+++ b/test/harmonic/test_dynmat_to_fc.py
@@ -10,7 +10,7 @@ from phonopy.harmonic.dynmat_to_fc import (
     DynmatToForceConstants,
     get_commensurate_points,
     get_commensurate_points_in_integers,
-    ph2fc,
+    ph2ph,
 )
 from phonopy.units import VaspToTHz
 
@@ -95,18 +95,21 @@ def _write(comm_points, filename="comm_points.dat"):
         w.write("\n".join(lines))
 
 
-def test_ph2fc(ph_nacl, ph_nacl_nonac):
-    """Test transformation of phonon to force constants.
-
-    Here effectively the interpolation in reciprocal space is performed.
-
-    """
-    for ph in (ph_nacl_nonac, ph_nacl):
-        fc333 = ph2fc(ph, np.diag([3, 3, 3]))
-        _phonons_allclose(ph, fc333)
+def test_ph2ph_with_nac(ph_nacl):
+    """Test transformation of phonon to force constants with NAC."""
+    ph = ph_nacl
+    fc333 = ph2ph(ph, np.diag([3, 3, 3]), with_nac=True).force_constants
+    _phonons_allclose(ph, fc333)
 
 
-def _phonons_allclose(ph, fc333):
+def test_ph2ph_without_nac(ph_nacl_nonac):
+    """Test transformation of phonon to force constants without NAC."""
+    ph = ph_nacl_nonac
+    fc333 = ph2ph(ph, np.diag([3, 3, 3]), with_nac=False).force_constants
+    _phonons_allclose(ph, fc333)
+
+
+def _phonons_allclose(ph: Phonopy, fc333):
     ph333 = Phonopy(
         ph.unitcell, supercell_matrix=[3, 3, 3], primitive_matrix=ph.primitive_matrix
     )


### PR DESCRIPTION
The feature of `dynmat_to_fc.ph2fc` function has been moved to `Phonopy.ph2ph`.  `dynmat_to_fc.ph2fc` is deprecated. Shortcut function `dynmat_to_fc.ph2ph` was implemented.

Fourier interpolation of force constants in a Phonopy class instance is performed by `Phonopy.ph2ph`. `Phonopy.ph2ph` returns new Phonopy class instance with the interpolated force constants. NAC is used to compute dynamical matrices at commensurate points with `with_nac=True` parameter, but NAC parameters are not copied to the returned Phonopy class instance.