### PR TITLE
Do not raise exception in loader without force-sets

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -42,6 +42,7 @@ from typing import Optional, Union
 
 import numpy as np
 
+from phonopy.exception import ForcesetsNotFoundError
 from phonopy.harmonic.displacement import (
     directions_to_displacement_dataset,
     get_least_displacements,
@@ -1035,9 +1036,9 @@ class Phonopy:
         if "first_atoms" in self._displacement_dataset:
             for disp in self._displacement_dataset["first_atoms"]:
                 if "forces" not in disp:
-                    raise RuntimeError("Forces are not yet set.")
+                    raise ForcesetsNotFoundError("Force sets are not yet set.")
         elif "forces" not in self._displacement_dataset:
-            raise RuntimeError("Forces are not yet set.")
+            raise ForcesetsNotFoundError("Force sets are not yet set.")
 
         if calculate_full_force_constants:
             self._run_force_constants_from_forces(

--- a/phonopy/cui/load.py
+++ b/phonopy/cui/load.py
@@ -70,15 +70,15 @@ def load(
 ) -> Phonopy:
     """Create Phonopy instance from parameters and/or input files.
 
-    "phonopy_yaml"-like file is parsed unless crystal structure information
-    is given by unitcell_filename, supercell_filename, unitcell
-    (PhonopyAtoms-like), or supercell (PhonopyAtoms-like).
-    Even when "phonopy_yaml"-like file is parse, parameters except for
-    crystal structure can be overwritten.
+    "phonopy_yaml"-like file is parsed unless crystal structure information is
+    given by unitcell_filename, supercell_filename, unitcell
+    (PhonopyAtoms-like), or supercell (PhonopyAtoms-like). Even when
+    "phonopy_yaml"-like file is parse, parameters except for crystal structure
+    can be overwritten.
 
-    Phonopy default files of 'FORCE_SETS' and 'BORN' are parsed when they
-    are found in current directory and those data are not yet provided by
-    other means.
+    Phonopy default files of 'FORCE_SETS' and 'BORN' are parsed when they are
+    found in current directory and those data are not yet provided by other
+    means.
 
     Crystal structure
     -----------------
@@ -91,8 +91,8 @@ def load(
 
     Force sets or force constants
     -----------------------------
-    Optional. Means to provide information to generate force constants
-    and their priority:
+    Optional. Means to provide information to generate force constants and their
+    priority:
         1. force_constants_filename
         2. force_sets_filename
         3. phonopy_yaml if force constants are found in phonoy_yaml.
@@ -101,8 +101,8 @@ def load(
         6. 'force_constants.hdf5' is searched in current directory.
         7. 'FORCE_SETS' is searched in current directory.
     When both of 3 and 4 are satisfied but not others, force constants and
-    dataset are stored in Phonopy instance, but force constants are not
-    produced from dataset.
+    dataset are stored in Phonopy instance, but force constants are not produced
+    from dataset.
 
     Parameters for non-analytical term correctiion (NAC)
     ----------------------------------------------------
@@ -115,36 +115,32 @@ def load(
     Parameters
     ----------
     phonopy_yaml : str, optional
-        Filename of "phonopy.yaml"-like file. If this is given, the data
-        in the file are parsed. Default is None.
+        Filename of "phonopy.yaml"-like file. If this is given, the data in the
+        file are parsed. Default is None.
     supercell_matrix : array_like, optional
-        Supercell matrix multiplied to input cell basis vectors.
-        shape=(3, ) or (3, 3), where the former is considered a diagonal
-        matrix. Default is the unit matrix.
-        dtype=int
+        Supercell matrix multiplied to input cell basis vectors. shape=(3, ) or
+        (3, 3), where the former is considered a diagonal matrix. Default is the
+        unit matrix. dtype=int
     primitive_matrix : array_like or str, optional
         Primitive matrix multiplied to input cell basis vectors. Default is
-        None, which is equivalent to 'auto'.
-        For array_like, shape=(3, 3), dtype=float.
-        When 'F', 'I', 'A', 'C', or 'R' is given instead of a 3x3 matrix,
-        the primitive matrix for the character found at
-        https://spglib.github.io/spglib/definition.html
-        is used.
+        None, which is equivalent to 'auto'. For array_like, shape=(3, 3),
+        dtype=float. When 'F', 'I', 'A', 'C', or 'R' is given instead of a 3x3
+        matrix, the primitive matrix for the character found at
+        https://spglib.github.io/spglib/definition.html is used.
     is_nac : bool, optional
-        If True, look for 'BORN' file. If False, NAS is turned off.
-        Default is True.
+        If True, look for 'BORN' file. If False, NAS is turned off. Default is
+        True.
     calculator : str, optional.
-        Calculator used for computing forces. This is used to switch the set
-        of physical units. Default is None, which is equivalent to "vasp".
+        Calculator used for computing forces. This is used to switch the set of
+        physical units. Default is None, which is equivalent to "vasp".
     unitcell : PhonopyAtoms, optional
         Input unit cell. Default is None.
     supercell : PhonopyAtoms, optional
-        Input supercell. With given, default value of primitive_matrix is set
-        to 'auto' (can be overwitten). supercell_matrix is ignored. Default is
+        Input supercell. With given, default value of primitive_matrix is set to
+        'auto' (can be overwitten). supercell_matrix is ignored. Default is
         None.
     nac_params : dict, optional
-        Parameters required for non-analytical term correction. Default is
-        None.
+        Parameters required for non-analytical term correction. Default is None.
         {'born': Born effective charges
                  (array_like, shape=(primitive cell atoms, 3, 3), dtype=float),
          'dielectric': Dielectric constant matrix
@@ -168,34 +164,32 @@ def load(
     fc_calculator : str, optional
         Force constants calculator. Currently only 'alm'. Default is None.
     fc_calculator_options : str, optional
-        Optional parameters that are passed to the external fc-calculator.
-        This is given as one text string. How to parse this depends on the
-        fc-calculator. For alm, each parameter is splitted by comma ',',
-        and each set of key and value pair is written in 'key = value'.
+        Optional parameters that are passed to the external fc-calculator. This
+        is given as one text string. How to parse this depends on the
+        fc-calculator. For alm, each parameter is splitted by comma ',', and
+        each set of key and value pair is written in 'key = value'.
     factor : float, optional
-        Phonon frequency unit conversion factor. Unless specified, default
-        unit conversion factor for each calculator is used.
+        Phonon frequency unit conversion factor. Unless specified, default unit
+        conversion factor for each calculator is used.
     frequency_scale_factor : float, optional
-        Factor multiplied to calculated phonon frequency. Default is None,
-        i.e., effectively 1.
+        Factor multiplied to calculated phonon frequency. Default is None, i.e.,
+        effectively 1.
     produce_fc : bool, optional
-        Setting False, force constants are not calculated from displacements
-        and forces. Default is True.
+        Setting False, force constants are not calculated from dataset of
+        displacements and forces even if the dataset exists. Default is True.
     is_symmetry : bool, optional
         Setting False, crystal symmetry except for lattice translation is not
         considered. Default is True.
     symmetrize_fc : bool, optional
-        Setting False, force constants are not symmetrized when creating
-        force constants from displacements and forces. Default is True.
+        Setting False, force constants are not symmetrized when creating force
+        constants from displacements and forces. Default is True.
     is_compact_fc : bool, optional
         Force constants are produced in the array whose shape is
-            True: (primitive, supecell, 3, 3)
-            False: (supercell, supecell, 3, 3)
+            True: (primitive, supecell, 3, 3) False: (supercell, supecell, 3, 3)
         where 'supercell' and 'primitive' indicate number of atoms in these
         cells. Default is True.
     store_dense_svecs : bool, optional
-        This is for the test use. Do not set True.
-        Default is False.
+        This is for the test use. Do not set True. Default is False.
     symprec : float, optional
         Tolerance used to find crystal symmetry. Default is 1e-5.
     log_level : int, optional

--- a/phonopy/cui/load_helper.py
+++ b/phonopy/cui/load_helper.py
@@ -38,6 +38,7 @@ import os
 import numpy as np
 
 from phonopy import Phonopy
+from phonopy.exception import ForcesetsNotFoundError
 from phonopy.file_IO import (
     parse_BORN,
     parse_FORCE_CONSTANTS,
@@ -284,15 +285,19 @@ def _produce_force_constants(
     is_compact_fc,
     log_level,
 ):
-    phonon.produce_force_constants(
-        calculate_full_force_constants=(not is_compact_fc),
-        fc_calculator=fc_calculator,
-        fc_calculator_options=fc_calculator_options,
-    )
-    if symmetrize_fc:
-        phonon.symmetrize_force_constants(show_drift=(log_level > 0))
+    try:
+        phonon.produce_force_constants(
+            calculate_full_force_constants=(not is_compact_fc),
+            fc_calculator=fc_calculator,
+            fc_calculator_options=fc_calculator_options,
+        )
+        if symmetrize_fc:
+            phonon.symmetrize_force_constants(show_drift=(log_level > 0))
+            if log_level:
+                print("Force constants were symmetrized.")
+    except ForcesetsNotFoundError:
         if log_level:
-            print("Force constants were symmetrized.")
+            print("Force constants not produced due to force set not found.")
 
 
 def _read_crystal_structure(filename=None, interface_mode=None):

--- a/phonopy/exception.py
+++ b/phonopy/exception.py
@@ -1,0 +1,40 @@
+"""Phonopy exceptions."""
+# Copyright (C) 2022 Atsushi Togo
+# All rights reserved.
+#
+# This file is part of phonopy.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+#
+# * Neither the name of the phonopy project nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+class ForcesetsNotFoundError(RuntimeError):
+    """Exception when forces not found in Phonopy class instance."""
+
+    pass

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -180,6 +180,13 @@ def ph_srtio3() -> Phonopy:
 
 
 @pytest.fixture(scope="session")
+def ph_nacl_unitcell_order1() -> Phonopy:
+    """Return Phonopy class instance of only NaCl unitcell with order-1."""
+    yaml_filename = cwd / "phonopy_NaCl_unitcell1.yaml"
+    return phonopy.load(yaml_filename, log_level=1, produce_fc=False)
+
+
+@pytest.fixture(scope="session")
 def ph_nacl_gruneisen() -> Tuple[Phonopy, Phonopy, Phonopy]:
     """Return Phonopy class instances of NaCl 2x2x2 at three volumes."""
     ph0 = phonopy.load(

--- a/test/exception.py
+++ b/test/exception.py
@@ -1,0 +1,12 @@
+"""Tests of custom exceptions."""
+import pytest
+
+from phonopy import Phonopy
+from phonopy.exception import ForcesetsNotFoundError
+
+
+def test_ForcesetsNotFoundError(ph_nacl_unitcell_order1: Phonopy):
+    """Test of ForcesetsNotFoundError."""
+    ph = ph_nacl_unitcell_order1
+    with pytest.raises(ForcesetsNotFoundError):
+        ph.produce_force_constants()

--- a/test/phonopy_NaCl_unitcell1.yaml
+++ b/test/phonopy_NaCl_unitcell1.yaml
@@ -1,0 +1,51 @@
+phonopy:
+  version: 2.7.0
+
+physical_unit:
+  atomic_mass: "AMU"
+  length: "angstrom"
+  force_constants: "eV/angstrom^2"
+
+space_group:
+  type: "Fm-3m"
+  number: 225
+  Hall_symbol: "-F 4 2 3"
+
+unit_cell:
+  lattice:
+  - [     5.690301476175671,     0.000000000000000,     0.000000000000000 ] # a
+  - [     0.000000000000000,     5.690301476175671,     0.000000000000000 ] # b
+  - [     0.000000000000000,     0.000000000000000,     5.690301476175671 ] # c
+  points:
+  - symbol: Na # 1
+    coordinates: [  0.000000000000000,  0.000000000000000,  0.000000000000000 ]
+    mass: 22.989769
+    reduced_to: 1
+  - symbol: Na # 2
+    coordinates: [  0.000000000000000,  0.500000000000000,  0.500000000000000 ]
+    mass: 22.989769
+    reduced_to: 1
+  - symbol: Na # 3
+    coordinates: [  0.500000000000000,  0.000000000000000,  0.500000000000000 ]
+    mass: 22.989769
+    reduced_to: 1
+  - symbol: Na # 4
+    coordinates: [  0.500000000000000,  0.500000000000000,  0.000000000000000 ]
+    mass: 22.989769
+    reduced_to: 1
+  - symbol: Cl # 5
+    coordinates: [  0.500000000000000,  0.500000000000000,  0.500000000000000 ]
+    mass: 35.453000
+    reduced_to: 5
+  - symbol: Cl # 6
+    coordinates: [  0.500000000000000,  0.000000000000000,  0.000000000000000 ]
+    mass: 35.453000
+    reduced_to: 5
+  - symbol: Cl # 7
+    coordinates: [  0.000000000000000,  0.500000000000000,  0.000000000000000 ]
+    mass: 35.453000
+    reduced_to: 5
+  - symbol: Cl # 8
+    coordinates: [  0.000000000000000,  0.000000000000000,  0.500000000000000 ]
+    mass: 35.453000
+    reduced_to: 5


### PR DESCRIPTION
When Phonopy.produce_force_constants() is called without forces-sets, exception is raised. This commit made phonopy loader not raise exception even when produce_fc=True and no force-sets.

This commit includes a phonopy custum exceptioon of ForcesetsNotFoundError for the case above, i.e.,  Phonopy.produce_force_constants() is called without forces-sets. Previously it was RuntimeError. For this custom exceptin, exception.py and the error, and its test were added.