### PR TITLE
New function rearrange_force_constants_array

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -2016,7 +2016,7 @@ class Phonopy:
             nac_q_direction=nac_q_direction,
         )
 
-    def get_qpoints_dict(self):
+    def get_qpoints_dict(self) -> dict:
         """Return calculated phonon properties at q-points.
 
         Returns

--- a/phonopy/harmonic/force_constants.py
+++ b/phonopy/harmonic/force_constants.py
@@ -45,6 +45,7 @@ from phonopy.structure.cells import (
     Primitive,
     compute_permutation_for_rotation,
     get_smallest_vectors,
+    isclose,
 )
 from phonopy.structure.symmetry import Symmetry
 from phonopy.utils import similarity_transformation
@@ -146,6 +147,34 @@ def full_fc_to_compact_fc(phonon: "Phonopy", full_fc, log_level=0):
         print("Force constants format was transformed to compact format.")
 
     return fc
+
+
+def rearrange_force_constants_array(
+    full_fc: np.ndarray, a: PhonopyAtoms, b: PhonopyAtoms
+) -> tuple[np.ndarray, list]:
+    """Rearrange force constants array of cell-a to those of cell-b.
+
+    Parameters
+    ----------
+    full_fc : ndarray
+        Force constants in full array format.
+    a : PhonopyAtoms
+        Cell of input force constants.
+    b : PhonopyAtoms
+        Cell of rearranged force constants.
+
+    Returns
+    -------
+    ndarray
+        Rearranged force constants array.
+
+    """
+    assert full_fc.shape[0] == full_fc.shape[1]
+    indices: list = isclose(a, b, with_arbitrary_order=True, return_order=True)
+    re_fc = np.zeros_like(full_fc)
+    for i, j in enumerate(indices):
+        re_fc[i] = full_fc[j][indices]
+    return re_fc, indices
 
 
 def cutoff_force_constants(

--- a/phonopy/harmonic/force_constants.py
+++ b/phonopy/harmonic/force_constants.py
@@ -33,6 +33,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 """Pytest configuration."""
-import os
 from pathlib import Path
 from typing import Tuple
 
@@ -10,14 +9,13 @@ import phonopy
 from phonopy import Phonopy
 from phonopy.structure.atoms import PhonopyAtoms
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
 cwd = Path(__file__).parent
 
 
 @pytest.fixture(scope="session")
 def ph_si() -> Phonopy:
     """Return Phonopy class instance of Si-prim 2x2x2."""
-    yaml_filename = os.path.join(current_dir, "phonopy_params_Si.yaml")
+    yaml_filename = cwd / "phonopy_params_Si.yaml"
     return phonopy.load(
         yaml_filename,
         is_compact_fc=False,
@@ -29,9 +27,9 @@ def ph_si() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_nacl() -> Phonopy:
     """Return Phonopy class instance of NaCl 2x2x2."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_NaCl.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_NaCl")
-    born_filename = os.path.join(current_dir, "BORN_NaCl")
+    yaml_filename = cwd / "phonopy_disp_NaCl.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_NaCl"
+    born_filename = cwd / "BORN_NaCl"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -45,9 +43,9 @@ def ph_nacl() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_nacl_nofcsym() -> Phonopy:
     """Return Phonopy class instance of NaCl 2x2x2 without symmetrizing fc2."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_NaCl.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_NaCl")
-    born_filename = os.path.join(current_dir, "BORN_NaCl")
+    yaml_filename = cwd / "phonopy_disp_NaCl.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_NaCl"
+    born_filename = cwd / "BORN_NaCl"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -61,9 +59,9 @@ def ph_nacl_nofcsym() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_nacl_compact_fcsym() -> Phonopy:
     """Return Phonopy class instance of NaCl 2x2x2 with compact fc2."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_NaCl.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_NaCl")
-    born_filename = os.path.join(current_dir, "BORN_NaCl")
+    yaml_filename = cwd / "phonopy_disp_NaCl.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_NaCl"
+    born_filename = cwd / "BORN_NaCl"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -77,8 +75,8 @@ def ph_nacl_compact_fcsym() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_nacl_nonac() -> Phonopy:
     """Return Phonopy class instance of NaCl 2x2x2 without NAC."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_NaCl.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_NaCl")
+    yaml_filename = cwd / "phonopy_disp_NaCl.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_NaCl"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -92,8 +90,8 @@ def ph_nacl_nonac() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_nacl_nonac_compact_fc() -> Phonopy:
     """Return Phonopy class instance of NaCl 2x2x2 without NAC with compact fc2."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_NaCl.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_NaCl")
+    yaml_filename = cwd / "phonopy_disp_NaCl.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_NaCl"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -107,8 +105,8 @@ def ph_nacl_nonac_compact_fc() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_nacl_nonac_dense_svecs() -> Phonopy:
     """Return Phonopy class instance of NaCl 2x2x2 without NAC with dense svecs."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_NaCl.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_NaCl")
+    yaml_filename = cwd / "phonopy_disp_NaCl.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_NaCl"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -123,9 +121,9 @@ def ph_nacl_nonac_dense_svecs() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_sno2() -> Phonopy:
     """Return Phonopy class instance of rutile SnO2 2x2x3."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_SnO2.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_SnO2")
-    born_filename = os.path.join(current_dir, "BORN_SnO2")
+    yaml_filename = cwd / "phonopy_disp_SnO2.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_SnO2"
+    born_filename = cwd / "BORN_SnO2"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -139,9 +137,9 @@ def ph_sno2() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_tio2() -> Phonopy:
     """Return Phonopy class instance of anataze TiO2 3x3x1."""
-    yaml_filename = os.path.join(current_dir, "phonopy_disp_TiO2.yaml")
-    force_sets_filename = os.path.join(current_dir, "FORCE_SETS_TiO2")
-    born_filename = os.path.join(current_dir, "BORN_TiO2")
+    yaml_filename = cwd / "phonopy_disp_TiO2.yaml"
+    force_sets_filename = cwd / "FORCE_SETS_TiO2"
+    born_filename = cwd / "BORN_TiO2"
     return phonopy.load(
         yaml_filename,
         force_sets_filename=force_sets_filename,
@@ -155,7 +153,7 @@ def ph_tio2() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_zr3n4() -> Phonopy:
     """Return Phonopy class instance of anataze Zr3N4 1x1x1."""
-    yaml_filename = os.path.join(current_dir, "phonopy_params_Zr3N4.yaml")
+    yaml_filename = cwd / "phonopy_params_Zr3N4.yaml"
     return phonopy.load(
         yaml_filename, is_compact_fc=False, log_level=1, produce_fc=True
     )
@@ -164,7 +162,7 @@ def ph_zr3n4() -> Phonopy:
 @pytest.fixture(scope="session")
 def ph_tipn3() -> Phonopy:
     """Return Phonopy class instance of anataze TiPN3 4x2x1."""
-    yaml_filename = os.path.join(current_dir, "phonopy_params_TiPN3.yaml.xz")
+    yaml_filename = cwd / "phonopy_params_TiPN3.yaml.xz"
     return phonopy.load(
         yaml_filename, is_compact_fc=False, log_level=1, produce_fc=True
     )
@@ -180,34 +178,20 @@ def ph_srtio3() -> Phonopy:
 
 
 @pytest.fixture(scope="session")
-def ph_nacl_unitcell_order1() -> Phonopy:
-    """Return Phonopy class instance of only NaCl unitcell with order-1."""
-    yaml_filename = cwd / "phonopy_NaCl_unitcell1.yaml"
-    return phonopy.load(yaml_filename, log_level=1, produce_fc=False)
-
-
-@pytest.fixture(scope="session")
-def ph_nacl_unitcell_order2() -> Phonopy:
-    """Return Phonopy class instance of only NaCl unitcell with order-2."""
-    yaml_filename = cwd / "phonopy_NaCl_unitcell2.yaml"
-    return phonopy.load(yaml_filename, log_level=1, produce_fc=False)
-
-
-@pytest.fixture(scope="session")
 def ph_nacl_gruneisen() -> Tuple[Phonopy, Phonopy, Phonopy]:
     """Return Phonopy class instances of NaCl 2x2x2 at three volumes."""
     ph0 = phonopy.load(
-        os.path.join(current_dir, "phonopy_params_NaCl-1.00.yaml.xz"),
+        cwd / "phonopy_params_NaCl-1.00.yaml.xz",
         log_level=1,
         produce_fc=True,
     )
     ph_minus = phonopy.load(
-        os.path.join(current_dir, "phonopy_params_NaCl-0.995.yaml.xz"),
+        cwd / "phonopy_params_NaCl-0.995.yaml.xz",
         log_level=1,
         produce_fc=True,
     )
     ph_plus = phonopy.load(
-        os.path.join(current_dir, "phonopy_params_NaCl-1.005.yaml.xz"),
+        cwd / "phonopy_params_NaCl-1.005.yaml.xz",
         log_level=1,
         produce_fc=True,
     )
@@ -240,22 +224,17 @@ def primcell_si() -> PhonopyAtoms:
 
 
 @pytest.fixture(scope="session")
-def convcell_nacl() -> PhonopyAtoms:
-    """Return PhonopyAtoms instance of conventional unit cell of NaCl."""
-    symbols = ["Na"] * 4 + ["Cl"] * 4
-    a = 5.6903014761756712
-    lattice = [[a, 0, 0], [0, a, 0], [0, 0, a]]
-    points = [
-        [0.0, 0.0, 0.0],
-        [0.0, 0.5, 0.5],
-        [0.5, 0.0, 0.5],
-        [0.5, 0.5, 0.0],
-        [0.5, 0.5, 0.5],
-        [0.5, 0.0, 0.0],
-        [0.0, 0.5, 0.0],
-        [0.0, 0.0, 0.5],
-    ]
-    return PhonopyAtoms(cell=lattice, scaled_positions=points, symbols=symbols)
+def nacl_unitcell_order1() -> PhonopyAtoms:
+    """Return Phonopy class instance of only NaCl unitcell with order-1."""
+    yaml_filename = cwd / "phonopy_NaCl_unitcell1.yaml"
+    return phonopy.load(yaml_filename, log_level=1, produce_fc=False).unitcell
+
+
+@pytest.fixture(scope="session")
+def nacl_unitcell_order2() -> PhonopyAtoms:
+    """Return Phonopy class instance of only NaCl unitcell with order-2."""
+    yaml_filename = cwd / "phonopy_NaCl_unitcell2.yaml"
+    return phonopy.load(yaml_filename, log_level=1, produce_fc=False).unitcell
 
 
 @pytest.fixture(scope="session")

--- a/test/structure/test_cells.py
+++ b/test/structure/test_cells.py
@@ -207,9 +207,9 @@ def test_get_supercell_primcell_si(primcell_si: PhonopyAtoms, nosnf, helper_meth
     _test_get_supercell_primcell_si(primcell_si, helper_methods, is_old_style=nosnf)
 
 
-def test_get_supercell_nacl_snf(convcell_nacl: PhonopyAtoms, helper_methods):
+def test_get_supercell_nacl_snf(nacl_unitcell_order1: PhonopyAtoms, helper_methods):
     """Test of get_supercell using SNF by NaCl."""
-    cell = convcell_nacl
+    cell = nacl_unitcell_order1
     smat = [[-1, 1, 1], [1, -1, 1], [1, 1, -1]]
     scell = get_supercell(cell, smat, is_old_style=True)
     scell_snf = get_supercell(cell, smat, is_old_style=False)
@@ -258,10 +258,10 @@ def _test_get_supercell_primcell_si(
 
 
 def test_get_primitive_convcell_nacl(
-    convcell_nacl: PhonopyAtoms, primcell_nacl: PhonopyAtoms, helper_methods
+    nacl_unitcell_order1: PhonopyAtoms, primcell_nacl: PhonopyAtoms, helper_methods
 ):
     """Test get_primitive by NaCl."""
-    pcell = get_primitive(convcell_nacl, primitive_matrix_nacl)
+    pcell = get_primitive(nacl_unitcell_order1, primitive_matrix_nacl)
     helper_methods.compare_cells_with_order(pcell, primcell_nacl)
 
 
@@ -278,11 +278,11 @@ def test_get_primitive_convcell_Cr(convcell_cr: PhonopyAtoms, helper_methods):
 
 @pytest.mark.parametrize("store_dense_svecs", [True, False])
 def test_get_primitive_convcell_nacl_svecs(
-    convcell_nacl: PhonopyAtoms, store_dense_svecs
+    nacl_unitcell_order1: PhonopyAtoms, store_dense_svecs
 ):
     """Test shortest vectors by NaCl."""
     pcell = get_primitive(
-        convcell_nacl, primitive_matrix_nacl, store_dense_svecs=store_dense_svecs
+        nacl_unitcell_order1, primitive_matrix_nacl, store_dense_svecs=store_dense_svecs
     )
     svecs, multi = pcell.get_smallest_vectors()
     if store_dense_svecs:
@@ -295,7 +295,7 @@ def test_get_primitive_convcell_nacl_svecs(
         assert multi.shape == (8, 2)
 
 
-def test_TrimmedCell(convcell_nacl: PhonopyAtoms, helper_methods):
+def test_TrimmedCell(nacl_unitcell_order1: PhonopyAtoms, helper_methods):
     """Test TrimmedCell by NaCl."""
     pmat = [[0, 0.5, 0.5], [0.5, 0, 0.5], [0.5, 0.5, 0]]
     smat2 = np.eye(3, dtype="intc") * 2
@@ -303,7 +303,7 @@ def test_TrimmedCell(convcell_nacl: PhonopyAtoms, helper_methods):
     smat3 = np.eye(3, dtype="intc") * 3
     pmat3 = np.dot(np.linalg.inv(smat3), pmat)
 
-    cell = convcell_nacl
+    cell = nacl_unitcell_order1
     scell2 = get_supercell(cell, smat2)
     scell3 = get_supercell(cell, smat3)
     n = len(scell3) // 2
@@ -386,11 +386,11 @@ def test_isclose(ph_nacl: Phonopy):
 
 
 def test_isclose_with_arbitrary_order(
-    ph_nacl_unitcell_order1: Phonopy, ph_nacl_unitcell_order2: Phonopy
+    nacl_unitcell_order1: PhonopyAtoms, nacl_unitcell_order2: PhonopyAtoms
 ):
     """Test of isclose with different order."""
-    cell1 = ph_nacl_unitcell_order1.unitcell
-    cell2 = ph_nacl_unitcell_order2.unitcell
+    cell1 = nacl_unitcell_order1
+    cell2 = nacl_unitcell_order2
     assert not isclose(cell1, cell2)
     _isclose = isclose(cell1, cell2, with_arbitrary_order=True)
     assert isinstance(_isclose, bool)

--- a/test/structure/test_symmetry.py
+++ b/test/structure/test_symmetry.py
@@ -12,10 +12,10 @@ from phonopy.structure.symmetry import (
 )
 
 
-def test_get_map_operations(convcell_nacl):
+def test_get_map_operations(nacl_unitcell_order1):
     """Test get_map_operations()."""
     symprec = 1e-5
-    cell = convcell_nacl
+    cell = nacl_unitcell_order1
     scell = get_supercell(cell, np.diag([2, 2, 2]), symprec=symprec)
     symmetry = Symmetry(scell, symprec=symprec)
     map_ops = symmetry.get_map_operations().copy()
@@ -89,7 +89,7 @@ def test_Symmetry_pointgroup(ph_tio2: Phonopy):
     assert ph_tio2.symmetry.pointgroup_symbol == r"4/mmm"
 
 
-def test_Symmetry_nosym_s2p_map(convcell_nacl: PhonopyAtoms):
+def test_Symmetry_nosym_s2p_map(nacl_unitcell_order1: PhonopyAtoms):
     """Test Symmetry with is_symmetry=False and s2p_map.
 
     This situation happens when making Symmetry with nosym for supercell in
@@ -97,7 +97,7 @@ def test_Symmetry_nosym_s2p_map(convcell_nacl: PhonopyAtoms):
 
     """
     ph = Phonopy(
-        convcell_nacl,
+        nacl_unitcell_order1,
         supercell_matrix=[2, 2, 2],
         primitive_matrix="F",
         is_symmetry=False,

--- a/test/test_exception.py
+++ b/test/test_exception.py
@@ -5,8 +5,8 @@ from phonopy import Phonopy
 from phonopy.exception import ForcesetsNotFoundError
 
 
-def test_ForcesetsNotFoundError(ph_nacl_unitcell_order1: Phonopy):
+def test_ForcesetsNotFoundError(nacl_unitcell_order1: Phonopy):
     """Test of ForcesetsNotFoundError."""
-    ph = ph_nacl_unitcell_order1
+    ph = Phonopy(nacl_unitcell_order1)
     with pytest.raises(ForcesetsNotFoundError):
         ph.produce_force_constants()


### PR DESCRIPTION
`rearrange_force_constants_array` is a function to rearrange force constants array data into force constants array of another supercell with different atom order. The another supercell is assumed to be the same crystal where only atoms are arranged in a different order.