### PR TITLE
Tests of tetrahedron method to compare implementations in C and Python

### DIFF
--- a/phonopy/phonon/dos.py
+++ b/phonopy/phonon/dos.py
@@ -275,7 +275,7 @@ class TotalDos(Dos):
             self._frequencies,
             self._mesh_object.grid_address,
             self._mesh_object.grid_mapping_table,
-            tm.get_tetrahedra(),
+            tm.tetrahedra,
         )
 
     def _get_density_of_states_at_freq(self, f):
@@ -460,7 +460,7 @@ class ProjectedDos(Dos):
             self._frequencies,
             self._mesh_object.grid_address,
             self._mesh_object.grid_mapping_table,
-            tm.get_tetrahedra(),
+            tm.tetrahedra,
             coef=self._eigvecs2,
         )
         self._projected_dos = pdos.T

--- a/phonopy/phonon/tetrahedron_mesh.py
+++ b/phonopy/phonon/tetrahedron_mesh.py
@@ -145,7 +145,7 @@ class TetrahedronMesh:
         """Return frequency points."""
         return self._frequency_points
 
-    def set(self, value="I", division_number=201, frequency_points=None):
+    def set(self, value="I", division_number=201, frequency_points=None, lang="C"):
         """Prepare environment to peform linear tetrahedron method."""
         self._grid_point_count = 0
         self._value = value
@@ -162,8 +162,8 @@ class TetrahedronMesh:
         num_freqs = len(self._frequency_points)
         self._integration_weights = np.zeros((num_freqs, num_band), dtype="double")
         reciprocal_lattice = np.linalg.inv(self._cell.cell)
-        self._tm = TetrahedronMethod(reciprocal_lattice, mesh=self._mesh)
-        self._relative_grid_address = self._tm.get_tetrahedra()
+        self._tm = TetrahedronMethod(reciprocal_lattice, mesh=self._mesh, lang=lang)
+        self._relative_grid_address = self._tm.tetrahedra
 
     def _prepare(self):
         ir_gp_indices = {}

--- a/phonopy/structure/tetrahedron_method.py
+++ b/phonopy/structure/tetrahedron_method.py
@@ -33,6 +33,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import warnings
+
 import numpy as np
 
 try:
@@ -43,23 +45,8 @@ except ImportError:
     print("Phonopy C-extension has to be built properly.")
     sys.exit(1)
 
-parallelepiped_vertices = np.array(
-    [
-        [0, 0, 0],
-        [1, 0, 0],
-        [0, 1, 0],
-        [1, 1, 0],
-        [0, 0, 1],
-        [1, 0, 1],
-        [0, 1, 1],
-        [1, 1, 1],
-    ],
-    dtype="int_",
-    order="C",
-)
 
-
-def get_tetrahedra_relative_grid_address(microzone_lattice):
+def get_tetrahedra_relative_grid_address(microzone_lattice, lang="C"):
     """Return relative (differences of) grid addresses from the central.
 
     Parameter
@@ -70,21 +57,32 @@ def get_tetrahedra_relative_grid_address(microzone_lattice):
 
     """
     relative_grid_address = np.zeros((24, 4, 3), dtype="int_", order="C")
-    phonoc.tetrahedra_relative_grid_address(
-        relative_grid_address, np.array(microzone_lattice, dtype="double", order="C")
-    )
-
+    if lang == "C":
+        phonoc.tetrahedra_relative_grid_address(
+            relative_grid_address,
+            np.array(microzone_lattice, dtype="double", order="C"),
+        )
+    else:
+        relative_grid_address = _get_relative_grid_addresses_from_microzone_lattice(
+            microzone_lattice
+        )[0]
     return relative_grid_address
 
 
-def get_all_tetrahedra_relative_grid_address():
+def get_all_tetrahedra_relative_grid_address(lang="C"):
     """Return relative grid addresses dataset.
 
     This exists only for the test.
 
     """
-    relative_grid_address = np.zeros((4, 24, 4, 3), dtype="int_")
-    phonoc.all_tetrahedra_relative_grid_address(relative_grid_address)
+    relative_grid_address = np.zeros((4, 24, 4, 3), dtype="int_", order="C")
+    if lang == "C":
+        phonoc.all_tetrahedra_relative_grid_address(relative_grid_address)
+    else:
+        for i in range(4):
+            relative_grid_address[i] = _get_relative_grid_addresses_from_main_diagonal(
+                i
+            )[0]
 
     return relative_grid_address
 
@@ -122,13 +120,15 @@ def get_tetrahedra_integration_weight(omegas, tetrahedra_omegas, function="I"):
 class TetrahedronMethod:
     """Class to perform linear tetrahedron method on regular grid locally."""
 
-    def __init__(self, primitive_vectors=None, mesh=None, lang="C"):
+    def __init__(self, primitive_vectors, mesh=None, lang="C"):
         """Init method.
 
         Parameters
         ----------
         primitive_vectors : ndarray
-            a, b, c in column vectors.
+            a, b, c in column vectors in reciprocal space. This is only used to
+            determine a main diagonal of parallelepiped. If None, the first
+            main diagonal in the dataset is chosen.
             shape=(3, 3)
         mesh : array_like
             Mesh numbers.
@@ -143,15 +143,14 @@ class TetrahedronMethod:
                 np.array(primitive_vectors, dtype="double", order="C") / mesh
             )
         self._lang = lang
-
         self._vertices = None
         self._relative_grid_addresses = None
         self._central_indices = None
         self._tetrahedra_omegas = None
         self._sort_indices = None
         self._omegas = None
-        self._set_relative_grid_addresses()
         self._integration_weight = None
+        self._set_relative_grid_addresses(lang=self._lang)
 
     def run(self, omegas, value="I"):
         """Perform tetrahedron method.
@@ -159,8 +158,13 @@ class TetrahedronMethod:
         Parameters
         ----------
         value : str of "I" or "J"
-            "I": Imaginary part (delta function).
-            "J": Integral function of imaginary part.
+            "I": Imaginary part (delta function). "J": Integral function of
+            imaginary part.
+
+        Note
+        ----
+        "C" or "Py" here has to be consistent with that of
+        self._set_relative_grid_addresses().
 
         """
         if self._lang == "C":
@@ -168,9 +172,21 @@ class TetrahedronMethod:
         else:
             self._run_py(omegas, value=value)
 
-    def get_tetrahedra(self):
+    @property
+    def tetrahedra(self):
         """Return relative grid addresses at vertices of tetrahedra."""
         return self._relative_grid_addresses
+
+    def get_tetrahedra(self):
+        """Return relative grid addresses at vertices of tetrahedra."""
+        warnings.warn(
+            (
+                "TetrahedronMethod.get_tetrahedra() is deprecated. "
+                "Use TetrahedronMethod.tetrahedra attribute instead."
+            ),
+            DeprecationWarning,
+        )
+        return self.tetrahedra
 
     def get_unique_tetrahedra_vertices(self):
         """Return unique grid indices in neighboring tetrahedra."""
@@ -196,6 +212,34 @@ class TetrahedronMethod:
     def get_integration_weight(self):
         """Return integration weights."""
         return self._integration_weight
+
+    def _set_relative_grid_addresses(self, lang="C"):
+        """Set dataset of relative grid addresses."""
+        if lang == "C":
+            if self._primitive_vectors is None:
+                rga = np.array(
+                    get_all_tetrahedra_relative_grid_address()[0],
+                    dtype="int_",
+                    order="C",
+                )
+            else:
+                rga = get_tetrahedra_relative_grid_address(self._primitive_vectors)
+            self._relative_grid_addresses = rga
+        else:
+            if self._primitive_vectors is None:
+                (
+                    relative_grid_addresses,
+                    central_indices,
+                ) = _get_relative_grid_addresses_from_main_diagonal(0)
+            else:
+                (
+                    relative_grid_addresses,
+                    central_indices,
+                ) = _get_relative_grid_addresses_from_microzone_lattice(
+                    self._primitive_vectors
+                )
+            self._relative_grid_addresses = relative_grid_addresses
+            self._central_indices = central_indices
 
     def _run_c(self, omegas, value="I"):
         self._integration_weight = get_tetrahedra_integration_weight(
@@ -244,68 +288,6 @@ class TetrahedronMethod:
                 sum_value += IJ(4, np.where(indices == ci)[0][0]) * gn(4)
 
         return sum_value / 6
-
-    def _create_tetrahedra(self):
-        #
-        #     6-------7
-        #    /|      /|
-        #   / |     / |
-        #  4-------5  |
-        #  |  2----|--3
-        #  | /     | /
-        #  |/      |/
-        #  0-------1
-        #
-        # i: vec        neighbours
-        # 0: O          1, 2, 4
-        # 1: a          0, 3, 5
-        # 2: b          0, 3, 6
-        # 3: a + b      1, 2, 7
-        # 4: c          0, 5, 6
-        # 5: c + a      1, 4, 7
-        # 6: c + b      2, 4, 7
-        # 7: c + a + b  3, 5, 6
-        a, b, c = self._primitive_vectors.T
-        diag_vecs = np.array(
-            [a + b + c, -a + b + c, a - b + c, a + b - c]  # 0-7  # 1-6  # 2-5
-        )  # 3-4
-        shortest_index = np.argmin(np.sum(diag_vecs**2, axis=1))
-        # vertices = [np.zeros(3), a, b, a + b, c, c + a, c + b, c + a + b]
-        if shortest_index == 0:
-            pairs = ((1, 3), (1, 5), (2, 3), (2, 6), (4, 5), (4, 6))
-            tetras = np.sort([[0, 7] + list(x) for x in pairs])
-        elif shortest_index == 1:
-            pairs = ((0, 2), (0, 4), (2, 3), (3, 7), (4, 5), (5, 7))
-            tetras = np.sort([[1, 6] + list(x) for x in pairs])
-        elif shortest_index == 2:
-            pairs = ((0, 1), (0, 4), (1, 3), (3, 7), (4, 6), (6, 7))
-            tetras = np.sort([[2, 5] + list(x) for x in pairs])
-        elif shortest_index == 3:
-            pairs = ((0, 1), (0, 2), (1, 5), (2, 6), (5, 7), (6, 7))
-            tetras = np.sort([[3, 4] + list(x) for x in pairs])
-        else:
-            assert False
-
-        self._vertices = tetras
-
-    def _set_relative_grid_addresses(self):
-        if self._lang == "C":
-            rga = get_tetrahedra_relative_grid_address(self._primitive_vectors)
-            self._relative_grid_addresses = rga
-        else:
-            self._create_tetrahedra()
-            relative_grid_addresses = np.zeros((24, 4, 3), dtype="int_")
-            central_indices = np.zeros(24, dtype="int_")
-            pos = 0
-            for i in range(8):
-                ppd_shifted = parallelepiped_vertices - parallelepiped_vertices[i]
-                for tetra in self._vertices:
-                    if i in tetra:
-                        central_indices[pos] = np.where(tetra == i)[0][0]
-                        relative_grid_addresses[pos, :, :] = ppd_shifted[tetra]
-                        pos += 1
-            self._relative_grid_addresses = relative_grid_addresses
-            self._central_indices = central_indices
 
     def _f(self, n, m):
         return (self._omega - self._vertices_omegas[m]) / (
@@ -687,3 +669,92 @@ class TetrahedronMethod:
 
     def _I_4(self):
         return 0.0
+
+
+def _create_tetrahedra(shortest_main_diagonal):
+    """Create dataset of six vertices.
+
+        6-------7
+        /|      /|
+        / |     / |
+        4-------5  |
+        |  2----|--3
+        | /     | /
+        |/      |/
+        0-------1
+
+    i: vec        neighbours
+    0: O          1, 2, 4
+    1: a          0, 3, 5
+    2: b          0, 3, 6
+    3: a + b      1, 2, 7
+    4: c          0, 5, 6
+    5: c + a      1, 4, 7
+    6: c + b      2, 4, 7
+    7: c + a + b  3, 5, 6
+
+    Four main diagonals: 0-7, 1-6, 2-5, 3-4
+
+    """
+    if shortest_main_diagonal == 0:
+        pairs = ((1, 3), (1, 5), (2, 3), (2, 6), (4, 5), (4, 6))
+        six_tetras = np.sort([[0, 7] + list(x) for x in pairs])
+    elif shortest_main_diagonal == 1:
+        pairs = ((0, 2), (0, 4), (2, 3), (3, 7), (4, 5), (5, 7))
+        six_tetras = np.sort([[1, 6] + list(x) for x in pairs])
+    elif shortest_main_diagonal == 2:
+        pairs = ((0, 1), (0, 4), (1, 3), (3, 7), (4, 6), (6, 7))
+        six_tetras = np.sort([[2, 5] + list(x) for x in pairs])
+    elif shortest_main_diagonal == 3:
+        pairs = ((0, 1), (0, 2), (1, 5), (2, 6), (5, 7), (6, 7))
+        six_tetras = np.sort([[3, 4] + list(x) for x in pairs])
+    else:
+        assert False
+
+    return six_tetras
+
+
+def _get_relative_grid_addresses_from_six_tetrahedra(six_tetras):
+    parallelepiped_vertices = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [0, 1, 1],
+            [1, 1, 1],
+        ],
+        dtype="int_",
+        order="C",
+    )
+    relative_grid_addresses = np.zeros((24, 4, 3), dtype="int_", order="C")
+    central_indices = np.zeros(24, dtype="int_")
+    pos = 0
+    for i in range(8):
+        ppd_shifted = parallelepiped_vertices - parallelepiped_vertices[i]
+        for tetra in six_tetras:
+            if i in tetra:
+                central_indices[pos] = np.where(tetra == i)[0][0]
+                relative_grid_addresses[pos, :, :] = ppd_shifted[tetra]
+                pos += 1
+    return relative_grid_addresses, central_indices
+
+
+def _get_relative_grid_addresses_from_microzone_lattice(microzone_lattice):
+    """Return relative grid addresses of given microzone lattice.
+
+    microzone lattice is given by column vectors.
+
+    """
+    a, b, c = microzone_lattice.T
+    main_diagonals = np.array([a + b + c, -a + b + c, a - b + c, a + b - c])
+    shortest_main_diagonal = np.argmin(np.sum(main_diagonals**2, axis=1))
+    return _get_relative_grid_addresses_from_main_diagonal(shortest_main_diagonal)
+
+
+def _get_relative_grid_addresses_from_main_diagonal(main_diagonal):
+    """Return relative grid addresses of given main diagonal."""
+    six_tetras = _create_tetrahedra(main_diagonal)
+    return _get_relative_grid_addresses_from_six_tetrahedra(six_tetras)

--- a/test/phonon/test_dos.py
+++ b/test/phonon/test_dos.py
@@ -54,7 +54,7 @@ pdos_thm_str = """-0.750122 0.000000 0.000000
 7.249878 0.000000 0.000000"""
 
 
-def testTotalDOS(ph_nacl_nofcsym):
+def testTotalDOS(ph_nacl_nofcsym: Phonopy):
     """Test of total DOS with smearing method."""
     phonon = ph_nacl_nofcsym
     phonon.run_mesh([5, 5, 5])
@@ -67,7 +67,7 @@ def testTotalDOS(ph_nacl_nofcsym):
     #     print("%f %f" % (f, d))
 
 
-def testTotalDOSTetrahedron(ph_nacl_nofcsym):
+def testTotalDOSTetrahedron(ph_nacl_nofcsym: Phonopy):
     """Test of total DOS with tetrahedron method."""
     phonon = ph_nacl_nofcsym
     phonon.run_mesh([5, 5, 5])
@@ -80,7 +80,7 @@ def testTotalDOSTetrahedron(ph_nacl_nofcsym):
     #     print("%f %f" % (f, d))
 
 
-def testProjectedlDOS(ph_nacl_nofcsym):
+def testProjectedlDOS(ph_nacl_nofcsym: Phonopy):
     """Test projected DOS with smearing method."""
     phonon = ph_nacl_nofcsym
     phonon.run_mesh([5, 5, 5], is_mesh_symmetry=False, with_eigenvectors=True)
@@ -93,7 +93,7 @@ def testProjectedlDOS(ph_nacl_nofcsym):
     #     print(("%f" + " %f" * len(d)) % ((f, ) + tuple(d)))
 
 
-def testPartialDOSTetrahedron(ph_nacl_nofcsym):
+def testPartialDOSTetrahedron(ph_nacl_nofcsym: Phonopy):
     """Test projected DOS with tetrahedron method."""
     phonon = ph_nacl_nofcsym
     phonon.run_mesh([5, 5, 5], is_mesh_symmetry=False, with_eigenvectors=True)


### PR DESCRIPTION
For the tetrahedron method, there are parts written in C and those are used as default. But corresponding python implementations exist, and this commit compares those in C and Python by tests.

In this investigation, I found the datasets of relative grid addressses obtained via C and Python are different, but both give the (almost) same result. Therefore their difference is in some order of vertice. Both seem correct, but this would be better carefully tested in the future.