### PR TITLE
Fix: find pseudo from STRU file of abacus

### DIFF
--- a/phonopy/interface/abacus.py
+++ b/phonopy/interface/abacus.py
@@ -60,7 +60,7 @@ def read_abacus(filename, elements=[]):
         if _search_sentence(file, "ATOMIC_SPECIES"):
             for it, elem in enumerate(elements):
                 line = _skip_notes(file.readline())
-                _, _, pseudo = line.split()
+                pseudo = line.split()[2]
                 pps.append(pseudo)
 
         if _search_sentence(file, "NUMERICAL_ORBITAL"):

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -1404,7 +1404,6 @@ def compute_permutation_for_rotation(
         shape=(len(positions), ), dtype=int
 
     """
-
     # Sort both sides by some measure which is likely to produce a small
     # maximum value of (sorted_rotated_index - sorted_original_index).
     # The C code is optimized for this case, reducing an O(n^2)

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -1404,11 +1404,13 @@ def compute_permutation_for_rotation(
         shape=(len(positions), ), dtype=int
 
     """
+
     def sort_by_lattice_distance(fracs):
         carts = np.dot(fracs - np.rint(fracs), lattice.T)
         perm = np.argsort(np.sum(carts**2, axis=1))
         sorted_fracs = np.array(fracs[perm], dtype="double", order="C")
         return perm, sorted_fracs
+
     # Sort both sides by some measure which is likely to produce a small
     # maximum value of (sorted_rotated_index - sorted_original_index).
     # The C code is optimized for this case, reducing an O(n^2)

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -1404,6 +1404,7 @@ def compute_permutation_for_rotation(
         shape=(len(positions), ), dtype=int
 
     """
+
     # Sort both sides by some measure which is likely to produce a small
     # maximum value of (sorted_rotated_index - sorted_original_index).
     # The C code is optimized for this case, reducing an O(n^2)

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -1404,18 +1404,17 @@ def compute_permutation_for_rotation(
         shape=(len(positions), ), dtype=int
 
     """
-
+    def sort_by_lattice_distance(fracs):
+        carts = np.dot(fracs - np.rint(fracs), lattice.T)
+        perm = np.argsort(np.sum(carts**2, axis=1))
+        sorted_fracs = np.array(fracs[perm], dtype="double", order="C")
+        return perm, sorted_fracs
     # Sort both sides by some measure which is likely to produce a small
     # maximum value of (sorted_rotated_index - sorted_original_index).
     # The C code is optimized for this case, reducing an O(n^2)
     # search down to ~O(n). (for O(n log n) work overall, including the sort)
     #
     # We choose distance from the nearest bravais lattice point as our measure.
-    def sort_by_lattice_distance(fracs):
-        carts = np.dot(fracs - np.rint(fracs), lattice.T)
-        perm = np.argsort(np.sum(carts**2, axis=1))
-        sorted_fracs = np.array(fracs[perm], dtype="double", order="C")
-        return perm, sorted_fracs
 
     (perm_a, sorted_a) = sort_by_lattice_distance(positions_a)
     (perm_b, sorted_b) = sort_by_lattice_distance(positions_b)


### PR DESCRIPTION
Dear Prof. Togo,

I open this pull request to treat the bug in finding pseudo file from the `STRU` file in the ABACUS interface. The reasons: the header of `STRU` can both be
```
ATOMIC_SPECIES
Mo 95.94 Mo_ONCV_PBE-1.0.upf
S 32.065 S_ONCV_PBE-1.0.upf
```
or
```
ATOMIC_SPECIES
Mo 95.94 Mo_ONCV_PBE-1.0.upf upf201
S 32.065 S_ONCV_PBE-1.0.upf upf201
```
For the latter case, the code will cause error. 

This PR is opened to fix this error. 

Thanks for your help.
Best,
Tianqi Zhao