### PR TITLE
Drop python 3.7 for running tests in github action

### DIFF
--- a/.github/workflows/phonopy-pytest-conda-openmp-site-cfg.yml
+++ b/.github/workflows/phonopy-pytest-conda-openmp-site-cfg.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
         conda activate test
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
-        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov
+        # conda install --yes -c conda-forge c-compiler
+        conda install --yes -c conda-forge matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov
     - name: Install cp2k-input-tools
       run: |
         conda activate test

--- a/.github/workflows/phonopy-pytest-conda-openmp-site-cfg.yml
+++ b/.github/workflows/phonopy-pytest-conda-openmp-site-cfg.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches-ignore:
     - publish-gh-pages
+    - develop
     - master
     - rc
   pull_request:
     branches: [ develop ]
-
 
 jobs:
   build-linux:
@@ -32,7 +32,7 @@ jobs:
       run: |
         conda activate test
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
-        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest
+        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov
     - name: Install cp2k-input-tools
       run: |
         conda activate test

--- a/.github/workflows/phonopy-pytest-conda-openmp.yml
+++ b/.github/workflows/phonopy-pytest-conda-openmp.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
     - publish-gh-pages
+    - develop
     - master
     - rc
   pull_request:
@@ -17,7 +18,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -46,6 +47,6 @@ jobs:
         conda activate test
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         verbose: true

--- a/.github/workflows/phonopy-pytest-conda-openmp.yml
+++ b/.github/workflows/phonopy-pytest-conda-openmp.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
         conda activate test
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
-        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest cmake
+        # conda install --yes -c conda-forge c-compiler
+        conda install --yes -c conda-forge matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest cmake
     - name: Install cp2k-input-tools
       run: |
         conda activate test

--- a/.github/workflows/phonopy-pytest-conda.yml
+++ b/.github/workflows/phonopy-pytest-conda.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
         conda activate test
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
-        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov
+        # conda install --yes -c conda-forge c-compiler
+        conda install --yes -c conda-forge matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov
     - name: Install cp2k-input-tools
       run: |
         conda activate test

--- a/.github/workflows/phonopy-pytest-conda.yml
+++ b/.github/workflows/phonopy-pytest-conda.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
     - publish-gh-pages
+    - develop
     - master
     - rc
   pull_request:
@@ -17,7 +18,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +32,7 @@ jobs:
       run: |
         conda activate test
         conda install --yes -c conda-forge python=${{ matrix.python-version }}
-        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov pytest
+        conda install --yes -c conda-forge c-compiler matplotlib-base pyyaml scipy numpy spglib h5py pip pytest codecov pytest-cov
     - name: Install cp2k-input-tools
       run: |
         conda activate test
@@ -45,6 +46,6 @@ jobs:
         conda activate test
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         verbose: true


### PR DESCRIPTION
In github action, `c-compiler` was removed from installation of conda forge packages. Therefore gcc in the system is used, and this is currently working. This makes tests finish in shorter time, but may cause compiler issue in the future.