### PR TITLE
Fix error message in QHA script

### DIFF
--- a/scripts/phonopy-qha
+++ b/scripts/phonopy-qha
@@ -219,9 +219,13 @@ def main(args):
             and (np.abs(temperatures - _temperatures[: len(temperatures)]) > 1e-5).any()
         ):
             print(
-                "Inconsistency is found in temperatures in %s and "
-                "thermal_properties.yaml files." % args.filenames[0]
+                f"Inconsistency is found in temperatures in {args.efe_file[0]} and "
+                "thermal_properties.yaml files."
             )
+            print("Temperatures in a thermal_properties.yaml are")
+            print(f"{temperatures}.")
+            print(f"Temperatures in {args.efe_file[0]} are")
+            print(f"{_temperatures.tolist()}.")
             sys.exit(1)
 
     ########################################################


### PR DESCRIPTION
After the fix, the error message looks like
```
# Vinet EOS
Inconsistency is found in temperatures in fe-v.dat and thermal_properties.yaml files.
Temperatures in a thermal_properties.yaml are
[0.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0, 550.0, 600.0, 650.0, 700.0, 750.0, 800.0, 850.0, 900.0, 950.0, 1000.0, 1050.0, 1100.0, 1150.0, 1200.0, 1250.0, 1300.0, 1350.0, 1400.0, 1450.0, 1500.0, 1550.0, 1600.0, 1650.0, 1700.0, 1750.0, 1800.0, 1850.0, 1900.0, 1950.0, 2000.0].
Temperatures in fe-v.dat are
[0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0, 1200.0, 1300.0, 1400.0, 1500.0].
```