### PR TITLE
Find max g_rad to reduce G_vec_list size

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -48,7 +48,7 @@ from phonopy.harmonic.displacement import (
     get_least_displacements,
     get_random_displacements_dataset,
 )
-from phonopy.harmonic.dynamical_matrix import get_dynamical_matrix
+from phonopy.harmonic.dynamical_matrix import DynamicalMatrixGL, get_dynamical_matrix
 from phonopy.harmonic.dynmat_to_fc import DynmatToForceConstants
 from phonopy.harmonic.force_constants import cutoff_force_constants
 from phonopy.harmonic.force_constants import get_fc2 as get_phonopy_fc2
@@ -3715,8 +3715,7 @@ class Phonopy:
             raise RuntimeError("Dynamical matrix has not yet built.")
 
         if (
-            self._dynamical_matrix.is_nac()
-            and self._dynamical_matrix.nac_method == "gonze"
+            isinstance(self._dynamical_matrix, DynamicalMatrixGL)
             and self._gv_delta_q is None
         ):
             if self._log_level:

--- a/phonopy/cui/phonopy_script.py
+++ b/phonopy/cui/phonopy_script.py
@@ -60,6 +60,7 @@ from phonopy.file_IO import (
     write_FORCE_CONSTANTS,
     write_force_constants_to_hdf5,
 )
+from phonopy.harmonic.dynamical_matrix import DynamicalMatrixNAC
 from phonopy.harmonic.force_constants import (
     compact_fc_to_full_fc,
     full_fc_to_compact_fc,
@@ -852,7 +853,7 @@ def store_nac_params(
             if log_level:
                 dm = phonon.dynamical_matrix
                 if dm is not None:
-                    if dm.is_nac():
+                    if isinstance(dm, DynamicalMatrixNAC):
                         dm.show_nac_message()
                     print("")
 

--- a/phonopy/gruneisen/core.py
+++ b/phonopy/gruneisen/core.py
@@ -101,7 +101,9 @@ class GruneisenBase:
         eigvals = []
         eigvecs = []
         for i, q in enumerate(self._qpoints):
-            if self._is_band_connection and self._dynmat.is_nac():
+            if self._is_band_connection and isinstance(
+                self._dynmat, DynamicalMatrixNAC
+            ):
                 self._dynmat.run(q, q_direction=self._q_direction)
             else:
                 self._dynmat.run(q)
@@ -140,7 +142,11 @@ class GruneisenBase:
         d_a: Union[DynamicalMatrix, DynamicalMatrixNAC],
         d_b: Union[DynamicalMatrix, DynamicalMatrixNAC],
     ):
-        if self._is_band_connection and d_a.is_nac() and d_b.is_nac():
+        if (
+            self._is_band_connection
+            and isinstance(d_a, DynamicalMatrixNAC)
+            and isinstance(d_b, DynamicalMatrixNAC)
+        ):
             d_a.run(q, q_direction=self._q_direction)
             d_b.run(q, q_direction=self._q_direction)
         else:

--- a/phonopy/harmonic/derivative_dynmat.py
+++ b/phonopy/harmonic/derivative_dynmat.py
@@ -138,7 +138,7 @@ class DerivativeOfDynamicalMatrix:
             (3, num_patom * 3, num_patom * 3),
             dtype=("c%d" % (np.dtype("double").itemsize * 2)),
         )
-        if self._dynmat.is_nac():
+        if isinstance(self._dynmat, DynamicalMatrixNAC):
             born = self._dynmat.born
             dielectric = self._dynmat.dielectric_constant
             nac_factor = self._dynmat.nac_factor
@@ -190,7 +190,7 @@ class DerivativeOfDynamicalMatrix:
         self._ddm = ddm
 
     def _run_py(self, q, q_direction=None):
-        if self._dynmat.is_nac():
+        if isinstance(self._dynmat, DynamicalMatrixNAC):
             if q_direction is None:
                 fc_nac = self._nac(q)
                 d_nac = self._d_nac(q)
@@ -239,7 +239,7 @@ class DerivativeOfDynamicalMatrix:
                 else:
                     coef = coef_order1
 
-                if self._dynmat.is_nac():
+                if isinstance(self._dynmat, DynamicalMatrixNAC):
                     fc_elem = fc[s_i, k] + fc_nac[i, j]
                 else:
                     fc_elem = fc[s_i, k]
@@ -247,8 +247,9 @@ class DerivativeOfDynamicalMatrix:
                 for ll in range(num_elem):
                     ddm_elem = fc_elem * (coef[:, ll] * phase_multi).sum()
                     if (
-                        self._dynmat.is_nac() and not self._derivative_order == 2
-                    ):  # noqa E129
+                        isinstance(self._dynmat, DynamicalMatrixNAC)
+                        and not self._derivative_order == 2
+                    ):
                         ddm_elem += d_nac[ll, i, j] * phase_multi.sum()
 
                     ddm_local[ll] += ddm_elem / mass / multi

--- a/phonopy/harmonic/dynamical_matrix.py
+++ b/phonopy/harmonic/dynamical_matrix.py
@@ -1226,7 +1226,7 @@ def run_dynamical_matrix_solver_c(
             Lambda,
         ) = gonze_nac_dataset  # Convergence parameter
         fc = gonze_fc
-    elif isinstance(dm, DynamicalMatrixWang):
+    else:
         positions = None
         dd_q0 = None
         G_list = None

--- a/phonopy/phonon/band_structure.py
+++ b/phonopy/phonon/band_structure.py
@@ -697,7 +697,6 @@ class BandStructure:
         self._set_frequencies()
 
     def _solve_dm_on_path(self, path):
-        is_nac = self._dynamical_matrix.is_nac()
         distances_on_path = []
         eigvals_on_path = []
         eigvecs_on_path = []
@@ -712,7 +711,7 @@ class BandStructure:
             self._shift_point(q)
             distances_on_path.append(self._distance)
 
-            if is_nac:
+            if isinstance(self._dynamical_matrix, DynamicalMatrixNAC):
                 q_direction = None
                 if (np.abs(q) < 0.0001).all():  # For Gamma point
                     q_direction = path[0] - path[-1]

--- a/phonopy/phonon/group_velocity.py
+++ b/phonopy/phonon/group_velocity.py
@@ -39,7 +39,11 @@ from typing import Optional, Union
 import numpy as np
 
 from phonopy.harmonic.derivative_dynmat import DerivativeOfDynamicalMatrix
-from phonopy.harmonic.dynamical_matrix import DynamicalMatrix, DynamicalMatrixNAC
+from phonopy.harmonic.dynamical_matrix import (
+    DynamicalMatrix,
+    DynamicalMatrixGL,
+    DynamicalMatrixNAC,
+)
 from phonopy.phonon.degeneracy import degenerate_sets
 from phonopy.structure.symmetry import Symmetry
 from phonopy.units import VaspToTHz
@@ -102,7 +106,7 @@ class GroupVelocity:
         self._reciprocal_lattice_inv = primitive.cell
         self._reciprocal_lattice = np.linalg.inv(self._reciprocal_lattice_inv)
         self._q_length = q_length
-        if self._dynmat.is_nac() and self._dynmat.nac_method == "gonze":
+        if isinstance(self._dynmat, DynamicalMatrixGL):
             if self._q_length is None:
                 self._q_length = self.Default_q_length
 

--- a/phonopy/phonon/qpoints.py
+++ b/phonopy/phonon/qpoints.py
@@ -280,7 +280,7 @@ class QpointsPhonon:
 
     def _get_dynamical_matrix(self, q):
         if (
-            self._dynamical_matrix.is_nac()
+            isinstance(self._dynamical_matrix, DynamicalMatrixNAC)
             and self._nac_q_direction is not None
             and (np.abs(q) < 1e-5).all()
         ):


### PR DESCRIPTION
- Find maximum `g_rad` to reduce memory usage of `G_vec_list`.
- Refactoring: Use of `DynamicalMatrix.is_nac()` was replaced by, e.g., `isinstance(dm, DynamicalMatrixNAC)`.