### PR TITLE
Fix import location of OptimizeWarning

### DIFF
--- a/phonopy/qha/eos.py
+++ b/phonopy/qha/eos.py
@@ -152,7 +152,7 @@ class EOSFit:
         except RuntimeError:
             logging.exception("Fitting to EOS failed.")
             raise
-        except (RuntimeWarning, scipy.optimize.optimize.OptimizeWarning):
+        except (RuntimeWarning, scipy.optimize.OptimizeWarning):
             logging.exception("Difficulty in fitting to EOS.")
             raise
         else:


### PR DESCRIPTION
scipy.optimize.optimize is deprecated and will be removed in scipy>=2.0.0. This patch fixes the import of scipy's OptimizeWarning to suppress DeprecationWarning.

c.f. https://github.com/scipy/scipy/blob/2353b154451fa77ee5f009b696ae82070ed8eab6/scipy/optimize/optimize.py#L1-L3