### PR TITLE
Fix show symmetry

### DIFF
--- a/phonopy/cui/phonopy_argparse.py
+++ b/phonopy/cui/phonopy_argparse.py
@@ -66,9 +66,7 @@ def show_deprecated_option_warnings(deprecated):
     print("")
 
 
-def get_parser(
-    fc_symmetry=False, is_nac=False, include_born=False, load_phonopy_yaml=False
-):
+def get_parser(fc_symmetry=False, is_nac=False, load_phonopy_yaml=False):
     """Return ArgumentParser instance."""
     deprecated = fix_deprecated_option_names(sys.argv)
     import argparse

--- a/phonopy/cui/phonopy_script.py
+++ b/phonopy/cui/phonopy_script.py
@@ -874,7 +874,7 @@ def store_nac_params(
                 print("-" * 76)
 
 
-def run(phonon: Phonopy, settings, cell_info, plot_conf, log_level):
+def run_calculation(phonon: Phonopy, settings, plot_conf, log_level):
     """Run phonon calculations."""
     interface_mode = phonon.calculator
     physical_units = get_default_physical_units(interface_mode)
@@ -1492,15 +1492,7 @@ def start_phonopy(**argparse_control):
         if deprecated:
             show_deprecated_option_warnings(deprecated)
 
-    return (
-        args,
-        log_level,
-        {
-            "plot_graph": args.is_graph_plot,
-            "save_graph": args.is_graph_save,
-            "with_legend": args.is_legend,
-        },
-    )
+    return args, log_level
 
 
 def read_phonopy_settings(args, argparse_control, log_level):
@@ -1761,7 +1753,17 @@ def main(**argparse_control):
     ############################################
     load_phonopy_yaml = argparse_control.get("load_phonopy_yaml", False)
 
-    args, log_level, plot_conf = start_phonopy(**argparse_control)
+    if "args" in argparse_control:  # For pytest
+        args = argparse_control["args"]
+        log_level = args.log_level
+    else:
+        args, log_level = start_phonopy(**argparse_control)
+
+    plot_conf = {
+        "plot_graph": args.is_graph_plot,
+        "save_graph": args.is_graph_save,
+        "with_legend": args.is_legend,
+    }
 
     settings, confs, cell_filename = read_phonopy_settings(
         args, argparse_control, log_level
@@ -1989,7 +1991,7 @@ def main(**argparse_control):
             print(" - %s" % mode)
         print("-" * 76)
 
-    run(phonon, settings, cell_info, plot_conf, log_level)
+    run_calculation(phonon, settings, plot_conf, log_level)
 
     ########################
     # Phonopy finalization #

--- a/phonopy/cui/show_symmetry.py
+++ b/phonopy/cui/show_symmetry.py
@@ -36,7 +36,6 @@
 
 import numpy as np
 import spglib
-from spglib import get_pointgroup
 
 from phonopy import Phonopy
 from phonopy.interface.calculator import (
@@ -57,9 +56,9 @@ def check_symmetry(phonon: Phonopy, optional_structure_info):
 
     if phonon.unitcell.magnetic_moments is None:
         base_fname = get_default_cell_filename(phonon.calculator)
-        symprec = phonon.primitive_symmetry.get_symmetry_tolerance()
+        symprec = phonon.primitive_symmetry.tolerance
         (bravais_lattice, bravais_pos, bravais_numbers) = spglib.refine_cell(
-            phonon.primitive, symprec
+            phonon.primitive.totuple(), symprec
         )
         bravais = PhonopyAtoms(
             numbers=bravais_numbers, scaled_positions=bravais_pos, cell=bravais_lattice
@@ -116,7 +115,7 @@ def _get_symmetry_yaml(cell: PhonopyAtoms, symmetry: Symmetry, phonopy_version=N
         spg_number = int(spg_number.replace("(", "").replace(")", ""))
         lines.append("space_group_type: '%s'" % spg_symbol)
         lines.append("space_group_number: %d" % spg_number)
-        lines.append("point_group_type: '%s'" % symmetry.get_pointgroup())
+        lines.append("point_group_type: '%s'" % symmetry.pointgroup_symbol)
     lines.append("space_group_operations:")
     for i, (r, t) in enumerate(zip(rotations, translations)):
         lines.append("- rotation: # %d" % (i + 1))
@@ -143,7 +142,7 @@ def _get_symmetry_yaml(cell: PhonopyAtoms, symmetry: Symmetry, phonopy_version=N
 
         if cell.magnetic_moments is None:
             lines.append("  Wyckoff: '%s'" % wyckoffs[i])
-        site_pointgroup = get_pointgroup(sitesym)
+        site_pointgroup = spglib.get_pointgroup(sitesym)
         lines.append("  site_point_group: '%s'" % site_pointgroup[0].strip())
         lines.append("  orientation:")
         for v in site_pointgroup[2]:

--- a/test/cui/test_phonopy_cui.py
+++ b/test/cui/test_phonopy_cui.py
@@ -1,0 +1,103 @@
+"""Tests of Phonopy --symmetry."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from collections.abc import Sequence
+from dataclasses import dataclass, fields
+from typing import Optional, Union
+
+import pytest
+
+from phonopy.cui.phonopy_script import main
+
+cwd = pathlib.Path(__file__).parent
+cwd_called = pathlib.Path.cwd()
+
+
+@dataclass
+class MockArgs:
+    """Mock args of ArgumentParser."""
+
+    filename: Optional[Sequence[os.PathLike]] = None
+    conf_filename: Optional[os.PathLike] = None
+    log_level: Optional[int] = None
+    fc_symmetry: bool = True
+    cell_filename: Optional[str] = None
+    is_check_symmetry: Optional[bool] = None
+    is_graph_plot: Optional[bool] = None
+    is_graph_save: Optional[bool] = None
+    is_legend: Optional[bool] = None
+
+    def __iter__(self):
+        """Make self iterable to support in."""
+        return (getattr(self, field.name) for field in fields(self))
+
+    def __contains__(self, item):
+        return item in (field.name for field in fields(self))
+
+
+def test_phonopy_load():
+    """Test phonopy-load command."""
+    # Check sys.exit(0)
+    argparse_control = _get_phonopy_load_args(
+        cwd / ".." / "phonopy_params_NaCl-1.00.yaml.xz"
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        main(**argparse_control)
+    assert excinfo.value.code == 0
+
+    # Clean files created by phonopy-load script.
+    for created_filename in ("phonopy.yaml",):
+        file_path = pathlib.Path(cwd_called / created_filename)
+        assert file_path.exists()
+        file_path.unlink()
+
+
+def test_phonopy_is_check_symmetry():
+    """Test phonopy --symmetry command."""
+    # Check sys.exit(0)
+    argparse_control = _get_phonopy_load_args(
+        cwd / ".." / "phonopy_params_NaCl-1.00.yaml.xz",
+        load_phonopy_yaml=False,
+        is_check_symmetry=True,
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        main(**argparse_control)
+    assert excinfo.value.code == 0
+
+    # Clean files created by phonopy --symmetry command.
+    for created_filename in ("BPOSCAR", "PPOSCAR", "phonopy_symcells.yaml"):
+        file_path = pathlib.Path(cwd_called / created_filename)
+        assert file_path.exists()
+        file_path.unlink()
+
+
+def _get_phonopy_load_args(
+    phonopy_yaml_filepath: Union[str, pathlib.Path],
+    load_phonopy_yaml: bool = True,
+    is_check_symmetry: bool = False,
+):
+    # Mock of ArgumentParser.args.
+    if load_phonopy_yaml:
+        mockargs = MockArgs(
+            filename=[phonopy_yaml_filepath],
+            log_level=1,
+        )
+    else:
+        mockargs = MockArgs(
+            filename=[],
+            log_level=1,
+            cell_filename=phonopy_yaml_filepath,
+            is_check_symmetry=is_check_symmetry,
+        )
+
+    # See phonopy-load script.
+    argparse_control = {
+        "fc_symmetry": load_phonopy_yaml,
+        "is_nac": load_phonopy_yaml,
+        "load_phonopy_yaml": load_phonopy_yaml,
+        "args": mockargs,
+    }
+    return argparse_control

--- a/test/phonon/test_irreps.py
+++ b/test/phonon/test_irreps.py
@@ -738,7 +738,7 @@ def test_pt03_P2():
     data = _load_data(chars_P2)
     phonon = _get_phonon("P2", [3, 2, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [[0, 0, 0.5]]  # V
     assert set(phonon.irreps.rotation_symbols) == set(["E", "C2"])
@@ -750,7 +750,7 @@ def test_pt04_Pc():
     data = _load_data(chars_Pc)
     phonon = _get_phonon("Pc", [2, 2, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [[0, 0.5, 0]]  # GA
     assert set(phonon.irreps.rotation_symbols) == set(["E", "sgh"])
@@ -762,7 +762,7 @@ def test_pt06_P222_1():
     data = _load_data(chars_P222_1)
     phonon = _get_phonon("P222_1", [2, 2, 1], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0.5, 0, 0],
@@ -782,7 +782,7 @@ def test_pt07_Amm2():
     data = _load_data(chars_Amm2)
     phonon = _get_phonon("Amm2", [3, 2, 2], [[1, 0, 0], [0, 0.5, -0.5], [0, 0.5, 0.5]])
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, -0.5],
@@ -800,7 +800,7 @@ def test_pt09_P4_1():
     data = _load_data(chars_P4_1)
     phonon = _get_phonon("P4_1", [2, 2, 1], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [[0, 0, 0.5]]
     assert set(phonon.irreps.rotation_symbols) == set(["E", "C4", "C2", "C4"])
@@ -812,7 +812,7 @@ def test_pt10_Pbar4():
     data = _load_data(chars_Pbar4)
     phonon = _get_phonon("P-4", [1, 1, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -830,7 +830,7 @@ def test_pt11_I4_1a():
         "I4_1a", [2, 2, 1], np.array([[-1, 1, 1], [1, -1, 1], [1, 1, -1]]) * 0.5
     )
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0.5, 0.5, -0.5],
@@ -849,7 +849,7 @@ def test_pt13_P4mm():
     data = _load_data(chars_P4mm)
     phonon = _get_phonon("P4mm", [3, 3, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -867,7 +867,7 @@ def test_pt14_Pbar42_1m():
     data = _load_data(chars_Pbar42_1m)
     phonon = _get_phonon("P-42_1m", [2, 2, 3], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0.5, 0.5, 0.5],
@@ -887,7 +887,7 @@ def test_pt19_P3m1():
     data = _load_data(chars_P3m1)
     phonon = _get_phonon("P3m1", [4, 4, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -904,7 +904,7 @@ def test_pt19_P31m():
     data = _load_data(chars_P31m)
     phonon = _get_phonon("P31m", [1, 1, 3], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     # _show_chars(chars)
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
@@ -922,7 +922,7 @@ def test_pt20_Pbar3m1():
     data = _load_data(chars_Pbar3m1)
     phonon = _get_phonon("P-3m1", [3, 3, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -942,7 +942,7 @@ def test_pt21_P6():
     data = _load_data(chars_P6)
     phonon = _get_phonon("P6", [2, 2, 1], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -959,7 +959,7 @@ def test_pt22_Pbar6():
     data = _load_data(chars_Pbar6)
     phonon = _get_phonon("P-6", [1, 1, 3], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -979,7 +979,7 @@ def test_pt24_P6_222():
     data = _load_data(chars_P6_222)
     phonon = _get_phonon("P6_222", [2, 2, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -999,7 +999,7 @@ def test_pt26_Pbar6m2():
     data = _load_data(chars_Pbar6m2)
     phonon = _get_phonon("P-6m2", [2, 2, 3], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0, 0, 0.5],
@@ -1017,7 +1017,7 @@ def test_pt28_P2_13():
     data = _load_data(chars_P2_13)
     phonon = _get_phonon("P2_13", [2, 2, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0.5, 0.5, 0.5],
@@ -1035,7 +1035,7 @@ def test_pt29_Pabar3():
     data = _load_data(chars_Pabar3)
     phonon = _get_phonon("Pa-3", [2, 2, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0.5, 0.5, 0.5],
@@ -1078,7 +1078,7 @@ def test_pt30_P4_332():
     data = _load_data(chars_P4_332)
     phonon = _get_phonon("P4_332", [1, 1, 1], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0.5, 0.5, 0.5],
@@ -1121,7 +1121,7 @@ def test_pt31_Pbar43m():
     data = _load_data(chars_Pbar43m)
     phonon = _get_phonon("P-43m", [2, 2, 2], np.eye(3))
     phonon.set_irreps([0, 0, 0])
-    chars = phonon.get_irreps().characters
+    chars = phonon.irreps.characters
     np.testing.assert_allclose(chars, data, atol=1e-5)
     qpoints = [
         [0.5, 0.5, 0.5],
@@ -1190,11 +1190,11 @@ def _check_char_sum(phonon: Phonopy, qpoints: List):
 
     for q in qpoints:
         phonon.set_irreps(q)
-        print(phonon.get_irreps().qpoint, end="")
-        order = len(phonon.get_irreps().conventional_rotations)
+        print(phonon.irreps.qpoint, end="")
+        order = len(phonon.irreps.conventional_rotations)
         char_sums = []
         for i, (irreps, chars) in enumerate(
-            zip(phonon.get_irreps().irreps, phonon.get_irreps().characters)
+            zip(phonon.irreps.irreps, phonon.irreps.characters)
         ):
             char_sum = 0
             for irrep, char in zip(irreps, chars):
@@ -1212,7 +1212,7 @@ def _check_char_sum(phonon: Phonopy, qpoints: List):
         if char_sums:  # Can be empty due to physically irreducible irreps.
             np.testing.assert_allclose(char_sums, order, atol=1e-5)
 
-        if len(char_sums) < len(phonon.get_irreps().irreps):
+        if len(char_sums) < len(phonon.irreps.irreps):
             print("  ** Physically irreps may exist. **")
         else:
             print()


### PR DESCRIPTION
phonopy --symmetry command raised exception of spglib because it used the deprecated crystal structure format of spglib. This was fixed. In this PR, simple tests for phonopy and phonopy-load commands were added.