### PR TITLE
Fix calculation of q_direction for band struture with NAC

### DIFF
--- a/phonopy/phonon/band_structure.py
+++ b/phonopy/phonon/band_structure.py
@@ -712,9 +712,7 @@ class BandStructure:
             distances_on_path.append(self._distance)
 
             if isinstance(self._dynamical_matrix, DynamicalMatrixNAC):
-                q_direction = None
-                if (np.abs(q) < 0.0001).all():  # For Gamma point
-                    q_direction = path[0] - path[-1]
+                q_direction = path[0] - path[-1]
                 self._dynamical_matrix.run(q, q_direction=q_direction)
             else:
                 self._dynamical_matrix.run(q)


### PR DESCRIPTION
This pull request enables the NAC for the entire phonon band path. 
Without this fix, the NAC is applied to the $\Gamma$ point only.

### Details

Before commit c2b1002, the `q_direction` is passed in as an argument of the `_solve_dm_on_path` function; after commit c2b1002 because no `q_direction` can be supplied, NAC is applied to $\Gamma$ point only.