### PR TITLE
Fix calculation of q_direction in BandStructure class

### DIFF
--- a/phonopy/phonon/band_structure.py
+++ b/phonopy/phonon/band_structure.py
@@ -707,14 +707,17 @@ class BandStructure:
             self._group_velocity.run(path)
             gv = self._group_velocity.group_velocities
 
+        if isinstance(self._dynamical_matrix, DynamicalMatrixNAC):
+            q_direction = None
+            # A cross product close to 0 indicates a path crossing or ending at Gamma
+            if (np.abs(np.cross(path[0], path[-1])) < 0.0001).all():
+                q_direction = path[0] - path[-1]
+
         for i, q in enumerate(path):
             self._shift_point(q)
             distances_on_path.append(self._distance)
 
             if isinstance(self._dynamical_matrix, DynamicalMatrixNAC):
-                q_direction = None
-                if (np.abs(q) < 0.0001).all():  # For Gamma point
-                    q_direction = path[0] - path[-1]
                 self._dynamical_matrix.run(q, q_direction=q_direction)
             else:
                 self._dynamical_matrix.run(q)


### PR DESCRIPTION
This pull request tries to address jumps in band structure near $\Gamma$ point when NAC is enabled.

<img width="1057" alt="image" src="https://github.com/phonopy/phonopy/assets/2217102/d90993ca-f57f-4d30-8556-2169ce3b04b0">

### Description

Originally, in `BandStructure`'s `_solve_dm_on_path` the criteria for testing if a path point is $\Gamma$ point is based on whether the fractional coordinate components are less than `0.0001`

```python3
if (np.abs(q) < 0.0001).all():
        q_direction = path[0] - path[-1]
```

if it satisfies this criterion, the direction is computed using the direction of the path.

However, in `DynamicalMatrixNAC`, the criteria is whether the `q_norm` is less than `self._symprec`.

```python3
        if q_direction is None:
            q_norm = np.linalg.norm(np.dot(q, self._rec_lat.T))
        else:
            q_norm = np.linalg.norm(np.dot(q_direction, self._rec_lat.T))

        if q_norm < self._symprec:
            self._run(q)
            return False
```

While sampling a q-path using the `BAND` tag, one can sample certain points that has a q's fractional components larger than 0.0001 but its `q_norm` smaller than `self._symprec` because the components of `self._rec_lat` is less than 1, for these points, there is no `q_direction` information, and the NAC is not applied. In bandplots, these points will jump.

To address this issue, I propose that if the path crosses `\Gamma`, the direction for all points should be assigned direction based on the coordinate of the initial and final points. To test if the path crosses $\Gamma$ or not, we can use the distance $d$ of the path to $\Gamma$, in the case of crossing, $d = 0$.

Assume a phonon band path is $\mathbf{q}_1$ to $\mathbf{q}_2$, the distance between $\Gamma$ to the path can be given by

$$
d = \frac{|(\mathbf{q}_1 \mathbf{B}) \times (\mathbf{q}_2 \mathbf{B}) |}{|(\mathbf{q}_1 - \mathbf{q}_2) \mathbf{B}|}
$$

where $\mathbf{B}$ is the reciprocal lattice matrix. Now, since we are interested in whether this path crosses $\Gamma$ point or not, we are only interested in knowing if $d = 0$, so we might test if $|\mathbf{q}_1 \times \mathbf{q}_2| = 0$ or not. Consider the special cases in that one end of this path is $\Gamma$, and the length of this cross product is exactly 0.

This cross-product criterion only needs to be tested once for each path, so it also saves some calculations.

### Settings file

```conf
DIM = 2 2 4
PRIMITIVE_AXIS = AUTO
BAND = 0.0 0.0 0.0 0.5 0.0 0.0 0.5 0.5 0.0 0.0 0.5 0.0 0.0 0.0 0.0 0.0 0.0 0.5 0.5 0.0 0.5 0.5 0.5 0.5 0.0 0.5 0.5 0.0 0.0 0.5, 0.5 0.0 0.0 0.5 0.0 0.5, 0.0 0.5 0.0 0.0 0.5 0.5, 0.5 0.5 0.0 0.5 0.5 0.5
BAND_LABLES = GAMMA X S Y GAMMA Z U R T Z, X U, Y T, S R
BAND_POINTS = 101
```