### PR TITLE
Improve tolerance to activate q-direction

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -3743,7 +3743,6 @@ class Phonopy:
             nac_params,
             self._frequency_scale_factor,
             self._dynamical_matrix_decimals,
-            symprec=self._symprec,
             log_level=self._log_level,
             use_openmp=phonoc.use_openmp(),
         )

--- a/phonopy/phonon/band_structure.py
+++ b/phonopy/phonon/band_structure.py
@@ -34,15 +34,18 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import gzip
 import sys
 import warnings
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import yaml
 
 from phonopy.harmonic.dynamical_matrix import DynamicalMatrix, DynamicalMatrixNAC
+from phonopy.phonon.group_velocity import GroupVelocity
 from phonopy.units import VaspToTHz
 
 
@@ -235,15 +238,15 @@ class BandStructure:
 
     def __init__(
         self,
-        paths,
+        paths: list,
         dynamical_matrix: Union[DynamicalMatrix, DynamicalMatrixNAC],
-        with_eigenvectors=False,
-        is_band_connection=False,
-        group_velocity=None,
-        path_connections=None,
-        labels=None,
-        is_legacy_plot=False,
-        factor=VaspToTHz,
+        with_eigenvectors: bool = False,
+        is_band_connection: bool = False,
+        group_velocity: Optional[GroupVelocity] = None,
+        path_connections: Optional[Union[list, bool]] = None,
+        labels: Optional[list[str]] = None,
+        is_legacy_plot: bool = False,
+        factor: float = VaspToTHz,
     ):
         """Init method.
 
@@ -316,7 +319,7 @@ class BandStructure:
         self._set_band()
 
     @property
-    def distances(self):
+    def distances(self) -> list:
         """Return distances of band segments."""
         return self._distances
 
@@ -330,7 +333,7 @@ class BandStructure:
         return self.distances
 
     @property
-    def qpoints(self):
+    def qpoints(self) -> list:
         """Return qpoints of band segments."""
         return self._paths
 
@@ -344,7 +347,7 @@ class BandStructure:
         return self.qpoints
 
     @property
-    def eigenvectors(self):
+    def eigenvectors(self) -> Optional[list]:
         """Return phonon eigenvectors of band segments."""
         return self._eigenvectors
 
@@ -358,7 +361,7 @@ class BandStructure:
         return self.eigenvectors
 
     @property
-    def frequencies(self):
+    def frequencies(self) -> Optional[list]:
         """Return phonon frequencies of band segments."""
         return self._frequencies
 
@@ -372,7 +375,7 @@ class BandStructure:
         return self.frequencies
 
     @property
-    def group_velocities(self):
+    def group_velocities(self) -> Optional[list]:
         """Return phonon group velocities of band segments."""
         return self._group_velocities
 
@@ -401,7 +404,7 @@ class BandStructure:
         return self._factor
 
     @property
-    def labels(self):
+    def labels(self) -> Optional[list]:
         """Return special point symbols."""
         return self._labels
 
@@ -411,7 +414,7 @@ class BandStructure:
         return self._path_connections
 
     @property
-    def is_legacy_plot(self):
+    def is_legacy_plot(self) -> bool:
         """Identify legacy plot or not."""
         return self._is_legacy_plot
 
@@ -710,7 +713,11 @@ class BandStructure:
         if isinstance(self._dynamical_matrix, DynamicalMatrixNAC):
             q_direction = None
             # A cross product close to 0 indicates a path crossing or ending at Gamma
-            if (np.abs(np.cross(path[0], path[-1])) < 0.0001).all():
+            rec_lat = np.linalg.inv(self._dynamical_matrix.primitive.cell)
+            dist_from_Gamma = np.linalg.norm(
+                np.cross(rec_lat @ path[0], rec_lat @ path[-1])
+            )
+            if dist_from_Gamma < DynamicalMatrixNAC.Q_DIRECTION_TOLERANCE:
                 q_direction = path[0] - path[-1]
 
         for i, q in enumerate(path):

--- a/test/phonon/test_band_structure.py
+++ b/test/phonon/test_band_structure.py
@@ -1,5 +1,7 @@
 """Tests for band structure calculation."""
 
+import numpy as np
+
 from phonopy.phonon.band_structure import get_band_qpoints
 
 
@@ -8,7 +10,13 @@ def test_band_structure(ph_nacl):
     ph_nacl.run_band_structure(
         _get_band_qpoints(), with_group_velocities=False, is_band_connection=False
     )
-    ph_nacl.get_band_structure_dict()
+    freqs = ph_nacl.get_band_structure_dict()["frequencies"]
+    assert len(freqs) == 3
+    assert freqs[0].shape == (11, 6)
+    np.testing.assert_allclose(
+        freqs[0][0], [0, 0, 0, 4.61643516, 4.61643516, 7.39632718], atol=1e-3
+    )
+    print(ph_nacl.get_band_structure_dict()["frequencies"])
 
 
 def test_band_structure_gv(ph_nacl):
@@ -16,15 +24,24 @@ def test_band_structure_gv(ph_nacl):
     ph_nacl.run_band_structure(
         _get_band_qpoints(), with_group_velocities=True, is_band_connection=False
     )
-    ph_nacl.get_band_structure_dict()
+    assert "group_velocities" in ph_nacl.get_band_structure_dict()
 
 
 def test_band_structure_bc(ph_nacl):
     """Test band structure calculation with band connection by NaCl."""
     ph_nacl.run_band_structure(
+        _get_band_qpoints(), with_group_velocities=False, is_band_connection=False
+    )
+    freqs = ph_nacl.get_band_structure_dict()["frequencies"]
+    ph_nacl.run_band_structure(
         _get_band_qpoints(), with_group_velocities=False, is_band_connection=True
     )
-    ph_nacl.get_band_structure_dict()
+    freqs_bc = ph_nacl.get_band_structure_dict()["frequencies"]
+
+    # Order of bands is changed by is_band_connection=True.
+    np.testing.assert_allclose(
+        freqs_bc[1][-1], freqs[1][-1][[0, 1, 5, 3, 4, 2]], atol=1e-3
+    )
 
 
 def _get_band_qpoints():


### PR DESCRIPTION
Further improvement to PR #338. The issue addressed by PR #338 became apparent when the tolerance is large. This PR contains refactoring and tests after PR #338.

- `symprec` was eliminated from `DynamicalMatrixNAC`.
- Magic number of `0.001` was replaced by `DynamicalMatrixNAC.Q_DIRECTION_TOLERANCE = 1e-5`
- Improve tests for band structure calculation