### PR TITLE
Update pwmat.py

### DIFF
--- a/phonopy/interface/pwmat.py
+++ b/phonopy/interface/pwmat.py
@@ -93,7 +93,8 @@ def read_atom_config(filename):
             read_lattice = True
         elif read_lattice:
             try:
-                lattice_vectors.append([float(part) for part in line.split()])
+                parts = [float(part) for part in line.split()[:3]]
+                lattice_vectors.append(parts[0:3])
             except ValueError:
                 read_lattice = False
 


### PR DESCRIPTION
Fix issue : Resolve lattice vector read-in issue in pwmat structure file
Issue Description:
The code fails to handle non-numeric strings when reading a line containing a lattice vector.
Solution:
Implemented a workaround to filter out non-numeric strings by reading the specific position of the line.
Changes Made:
- Updated code logic to properly handle non-numeric strings in lattice vector read-in process
- Implemented a filtering mechanism to ensure only numeric values are processed
![image](https://github.com/phonopy/phonopy/assets/162275244/bf2c5869-65f2-4947-b4d8-02ae1c3bda1b)

