### PR TITLE
support for use tag magmom

### DIFF
--- a/phonopy/interface/pwmat.py
+++ b/phonopy/interface/pwmat.py
@@ -117,6 +117,15 @@ def read_atom_config(filename):
                 element_mag.append(float(line.split()[1]))
             except ValueError:
                 read_magnetic = False
+                
+        if line.lower().startswith("magnetic_xyz"):
+            read_magnetic = True
+        elif read_magnetic:
+            try:
+                parts = [float(part) for part in line.split()]
+                element_mag.append(parts[1:4])
+            except ValueError:
+                read_magnetic = False
 
     cell_args = {
         "numbers": element_index,
@@ -153,10 +162,15 @@ def get_pwmat_structure(cell):
             + "   ".join(f"{val:.16f}" for val in position)
             + "  1   1   1"
         )
-    if isinstance(mag_mom, np.ndarray) and mag_mom.size > 0:
-        line.append("magnetic")
-        for number, mag in zip(numbers, mag_mom):
-            line.append(f" {number}  {mag:.16f}")
+    if mag_mom is not None and len(mag_mom) == len(cell.numbers):
+        if  len(mag_mom[0])==1:
+            line.append("magnetic")
+            for number, mag in zip(numbers, mag_mom):
+                line.append(f" {number}  {mag:.16f}")
+        if  len(mag_mom[0])==3:
+            line.append("magnetic_xyz")
+            for number, mag in zip(numbers, mag_mom):
+                line.append(f" {number}  {mag[0]:.6f} {mag[1]:.6f} {mag[2]:.6f}")
     return "\n".join(line)
 
 

--- a/phonopy/interface/pwmat.py
+++ b/phonopy/interface/pwmat.py
@@ -117,7 +117,7 @@ def read_atom_config(filename):
                 element_mag.append(float(line.split()[1]))
             except ValueError:
                 read_magnetic = False
-                
+
         if line.lower().startswith("magnetic_xyz"):
             read_magnetic = True
         elif read_magnetic:
@@ -163,11 +163,11 @@ def get_pwmat_structure(cell):
             + "  1   1   1"
         )
     if mag_mom is not None and len(mag_mom) == len(cell.numbers):
-        if  len(mag_mom[0])==1:
+        if len(mag_mom[0]) == 1:
             line.append("magnetic")
             for number, mag in zip(numbers, mag_mom):
                 line.append(f" {number}  {mag:.16f}")
-        if  len(mag_mom[0])==3:
+        if len(mag_mom[0]) == 3:
             line.append("magnetic_xyz")
             for number, mag in zip(numbers, mag_mom):
                 line.append(f" {number}  {mag[0]:.6f} {mag[1]:.6f} {mag[2]:.6f}")


### PR DESCRIPTION
Adapted to new version for caculator PWmat
added writing of magnetic moments and non-collinear magnetic moments

```
if mag_mom is not None and len(mag_mom) == len(cell.numbers):
        if  len(mag_mom[0])==1:
            line.append("magnetic")
            for number, mag in zip(numbers, mag_mom):
                line.append(f" {number}  {mag:.16f}")
        if  len(mag_mom[0])==3:
            line.append("magnetic_xyz")
            for number, mag in zip(numbers, mag_mom):
                line.append(f" {number}  {mag[0]:.6f} {mag[1]:.6f} {mag[2]:.6f}")  
```