### PR TITLE
support non-collinear magmom add for PWmat caculator

### DIFF
--- a/phonopy/interface/pwmat.py
+++ b/phonopy/interface/pwmat.py
@@ -117,6 +117,15 @@ def read_atom_config(filename):
                 element_mag.append(float(line.split()[1]))
             except ValueError:
                 read_magnetic = False
+                
+        if line.lower().startswith("magnetic_xyz"):
+            read_magnetic = True
+        elif read_magnetic:
+            try:
+                parts = [float(part) for part in line.split()]
+                element_mag.append(parts[1:4])
+            except ValueError:
+                read_magnetic = False
 
     cell_args = {
         "numbers": element_index,
@@ -153,10 +162,15 @@ def get_pwmat_structure(cell):
             + "   ".join(f"{val:.16f}" for val in position)
             + "  1   1   1"
         )
-    if isinstance(mag_mom, np.ndarray) and mag_mom.size > 0:
-        line.append("magnetic")
-        for number, mag in zip(numbers, mag_mom):
-            line.append(f" {number}  {mag:.16f}")
+    if mag_mom is not None and len(mag_mom) == len(cell.numbers):
+        if  len(mag_mom[0])==1:
+            line.append("magnetic")
+            for number, mag in zip(numbers, mag_mom):
+                line.append(f" {number}  {mag:.16f}")
+        if  len(mag_mom[0])==3:
+            line.append("magnetic_xyz")
+            for number, mag in zip(numbers, mag_mom):
+                line.append(f" {number}  {mag[0]:.6f} {mag[1]:.6f} {mag[2]:.6f}")
     return "\n".join(line)
 
 

--- a/phonopy/interface/pwmat.py
+++ b/phonopy/interface/pwmat.py
@@ -150,6 +150,7 @@ def get_pwmat_structure(cell):
     positions = cell.scaled_positions
     numbers = cell.numbers
     mag_mom = cell.magnetic_moments
+
     line = []
     line.append(f" {len(positions)}")
     line.append("Lattice vector (Angstrom)")
@@ -163,10 +164,12 @@ def get_pwmat_structure(cell):
             + "  1   1   1"
         )
     if mag_mom is not None and len(mag_mom) == len(cell.numbers):
+
         if len(mag_mom[0]) == 1:
             line.append("magnetic")
             for number, mag in zip(numbers, mag_mom):
                 line.append(f" {number}  {mag:.16f}")
+
         if len(mag_mom[0]) == 3:
             line.append("magnetic_xyz")
             for number, mag in zip(numbers, mag_mom):

--- a/phonopy/interface/pwmat.py
+++ b/phonopy/interface/pwmat.py
@@ -117,7 +117,7 @@ def read_atom_config(filename):
                 element_mag.append(float(line.split()[1]))
             except ValueError:
                 read_magnetic = False
-                
+
         if line.lower().startswith("magnetic_xyz"):
             read_magnetic = True
         elif read_magnetic:
@@ -163,11 +163,11 @@ def get_pwmat_structure(cell):
             + "  1   1   1"
         )
     if mag_mom is not None and len(mag_mom) == len(cell.numbers):
-        if  len(mag_mom[0])==1:
+        if len(mag_mom[0]) == 1:
             line.append("magnetic")
             for number, mag in zip(numbers, mag_mom):
                 line.append(f" {number}  {mag:.16f}")
-        if  len(mag_mom[0])==3:
+        if len(mag_mom[0]) == 3:
             line.append("magnetic_xyz")
             for number, mag in zip(numbers, mag_mom):
                 line.append(f" {number}  {mag[0]:.6f} {mag[1]:.6f} {mag[2]:.6f}")

--- a/phonopy/interface/pwmat.py
+++ b/phonopy/interface/pwmat.py
@@ -165,12 +165,12 @@ def get_pwmat_structure(cell):
         )
     if mag_mom is not None and len(mag_mom) == len(cell.numbers):
 
-        if len(mag_mom[0]) == 1:
+        if np.size(mag_mom[0]) == 1:
             line.append("magnetic")
             for number, mag in zip(numbers, mag_mom):
                 line.append(f" {number}  {mag:.16f}")
 
-        if len(mag_mom[0]) == 3:
+        if np.size(mag_mom[0]) == 3:
             line.append("magnetic_xyz")
             for number, mag in zip(numbers, mag_mom):
                 line.append(f" {number}  {mag[0]:.6f} {mag[1]:.6f} {mag[2]:.6f}")

--- a/test/interface/Si-pwmat.yaml
+++ b/test/interface/Si-pwmat.yaml
@@ -1,23 +1,23 @@
 phonopy:
-  version: "2.21.2"
+  version: "2.23.1"
   calculator: pwmat
   frequency_unit_conversion_factor: 15.633302
   symmetry_tolerance: 1.00000e-05
   configuration:
+    cell_filename: "atom.config"
+    create_displacements: ".true."
+    magmom: "1 1 1 1 1 1 1 1"
+    primitive_axes: "F"
     dim: "2 2 2"
-    atom_name: "Si"
-    mp: "31 31 31"
-    tprop: ".true."
+    calculator: "pwmat"
 
 physical_unit:
   atomic_mass: "AMU"
   length: "angstrom"
-  force_constants: "eV/angstrom^2"
 
-space_group:
-  type: "Fd-3m"
-  number: 227
-  Hall_symbol: "F 4d 2 3 -1d"
+magnetic_space_group:
+  uni_number: 1630
+  msg_type: 1
 
 primitive_matrix:
 - [  0.000000000000000,  0.500000000000000,  0.500000000000000 ]
@@ -38,9 +38,11 @@ primitive_cell:
   - symbol: Si # 1
     coordinates: [  0.000000000000000,  0.000000000000000,  0.000000000000000 ]
     mass: 28.085500
+    magnetic_moment: 1.00000000
   - symbol: Si # 2
     coordinates: [  0.250000000000000,  0.250000000000000,  0.250000000000000 ]
     mass: 28.085500
+    magnetic_moment: 1.00000000
   reciprocal_lattice: # without 2pi
   - [    -0.182807991366520,     0.182807991366520,     0.182807991366520 ] # a*
   - [     0.182807991366520,    -0.182807991366520,     0.182807991366520 ] # b*
@@ -56,34 +58,42 @@ unit_cell:
     coordinates: [  0.000000000000000,  0.000000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 2
     coordinates: [  0.250000000000000,  0.250000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 2
+    magnetic_moment: 1.00000000
   - symbol: Si # 3
     coordinates: [  0.000000000000000,  0.500000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 4
     coordinates: [  0.750000000000000,  0.250000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 2
+    magnetic_moment: 1.00000000
   - symbol: Si # 5
     coordinates: [  0.250000000000000,  0.750000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 2
+    magnetic_moment: 1.00000000
   - symbol: Si # 6
     coordinates: [  0.750000000000000,  0.750000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 2
+    magnetic_moment: 1.00000000
   - symbol: Si # 7
     coordinates: [  0.500000000000000,  0.000000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 8
     coordinates: [  0.500000000000000,  0.500000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
 
 supercell:
   lattice:
@@ -95,255 +105,324 @@ supercell:
     coordinates: [  0.000000000000000,  0.000000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 2
     coordinates: [  0.500000000000000,  0.000000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 3
     coordinates: [  0.000000000000000,  0.500000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 4
     coordinates: [  0.500000000000000,  0.500000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 5
     coordinates: [  0.000000000000000,  0.000000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 6
     coordinates: [  0.500000000000000,  0.000000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 7
     coordinates: [  0.000000000000000,  0.500000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 8
     coordinates: [  0.500000000000000,  0.500000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 9
     coordinates: [  0.125000000000000,  0.125000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 10
     coordinates: [  0.625000000000000,  0.125000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 11
     coordinates: [  0.125000000000000,  0.625000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 12
     coordinates: [  0.625000000000000,  0.625000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 13
     coordinates: [  0.125000000000000,  0.125000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 14
     coordinates: [  0.625000000000000,  0.125000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 15
     coordinates: [  0.125000000000000,  0.625000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 16
     coordinates: [  0.625000000000000,  0.625000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 17
     coordinates: [  0.000000000000000,  0.250000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 18
     coordinates: [  0.500000000000000,  0.250000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 19
     coordinates: [  0.000000000000000,  0.750000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 20
     coordinates: [  0.500000000000000,  0.750000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 21
     coordinates: [  0.000000000000000,  0.250000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 22
     coordinates: [  0.500000000000000,  0.250000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 23
     coordinates: [  0.000000000000000,  0.750000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 24
     coordinates: [  0.500000000000000,  0.750000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 25
     coordinates: [  0.375000000000000,  0.125000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 26
     coordinates: [  0.875000000000000,  0.125000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 27
     coordinates: [  0.375000000000000,  0.625000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 28
     coordinates: [  0.875000000000000,  0.625000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 29
     coordinates: [  0.375000000000000,  0.125000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 30
     coordinates: [  0.875000000000000,  0.125000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 31
     coordinates: [  0.375000000000000,  0.625000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 32
     coordinates: [  0.875000000000000,  0.625000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 33
     coordinates: [  0.125000000000000,  0.375000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 34
     coordinates: [  0.625000000000000,  0.375000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 35
     coordinates: [  0.125000000000000,  0.875000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 36
     coordinates: [  0.625000000000000,  0.875000000000000,  0.375000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 37
     coordinates: [  0.125000000000000,  0.375000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 38
     coordinates: [  0.625000000000000,  0.375000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 39
     coordinates: [  0.125000000000000,  0.875000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 40
     coordinates: [  0.625000000000000,  0.875000000000000,  0.875000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 41
     coordinates: [  0.375000000000000,  0.375000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 42
     coordinates: [  0.875000000000000,  0.375000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 43
     coordinates: [  0.375000000000000,  0.875000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 44
     coordinates: [  0.875000000000000,  0.875000000000000,  0.125000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 45
     coordinates: [  0.375000000000000,  0.375000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 46
     coordinates: [  0.875000000000000,  0.375000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 47
     coordinates: [  0.375000000000000,  0.875000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 48
     coordinates: [  0.875000000000000,  0.875000000000000,  0.625000000000000 ]
     mass: 28.085500
     reduced_to: 9
+    magnetic_moment: 1.00000000
   - symbol: Si # 49
     coordinates: [  0.250000000000000,  0.000000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 50
     coordinates: [  0.750000000000000,  0.000000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 51
     coordinates: [  0.250000000000000,  0.500000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 52
     coordinates: [  0.750000000000000,  0.500000000000000,  0.250000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 53
     coordinates: [  0.250000000000000,  0.000000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 54
     coordinates: [  0.750000000000000,  0.000000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 55
     coordinates: [  0.250000000000000,  0.500000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 56
     coordinates: [  0.750000000000000,  0.500000000000000,  0.750000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 57
     coordinates: [  0.250000000000000,  0.250000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 58
     coordinates: [  0.750000000000000,  0.250000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 59
     coordinates: [  0.250000000000000,  0.750000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 60
     coordinates: [  0.750000000000000,  0.750000000000000,  0.000000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 61
     coordinates: [  0.250000000000000,  0.250000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 62
     coordinates: [  0.750000000000000,  0.250000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 63
     coordinates: [  0.250000000000000,  0.750000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
   - symbol: Si # 64
     coordinates: [  0.750000000000000,  0.750000000000000,  0.500000000000000 ]
     mass: 28.085500
     reduced_to: 1
+    magnetic_moment: 1.00000000
+
+displacements:
+- atom:    1
+  displacement:
+    [   0.0100000000000000,  0.0000000000000000,  0.0000000000000000 ]

--- a/test/interface/test_pwmat.py
+++ b/test/interface/test_pwmat.py
@@ -22,3 +22,13 @@ def test_read_pwmat():
     assert (np.abs(diff_pos) < 1e-5).all()
     for s, s_r in zip(cell.symbols, cell_ref.symbols):
         assert s == s_r
+
+
+def test_magmom():
+    """Test of read_PWmat_magmom."""
+    cell = read_atom_config(os.path.join(data_dir, "Si-pwmat.config"))
+    filename = os.path.join(data_dir, "Si-pwmat.yaml")
+    cell_ref = read_cell_yaml(filename)
+    assert cells.isclose(cell, cell_ref)
+    diff_mag = cell_ref.magnetic_moments - np.array([1] * 8 )
+    assert (np.abs(diff_mag) < 1e-5).all()

--- a/test/interface/test_pwmat.py
+++ b/test/interface/test_pwmat.py
@@ -32,4 +32,3 @@ def test_magmom():
     assert cells.isclose(cell, cell_ref)
     diff_mag = cell_ref.magnetic_moments - np.array([1] * 8)
     assert (np.abs(diff_mag) < 1e-5).all()
-

--- a/test/interface/test_pwmat.py
+++ b/test/interface/test_pwmat.py
@@ -30,5 +30,5 @@ def test_magmom():
     filename = os.path.join(data_dir, "Si-pwmat.yaml")
     cell_ref = read_cell_yaml(filename)
     assert cells.isclose(cell, cell_ref)
-    diff_mag = cell_ref.magnetic_moments - np.array([1] * 8 )
+    diff_mag = cell_ref.magnetic_moments - np.array([1] * 8)
     assert (np.abs(diff_mag) < 1e-5).all()

--- a/test/interface/test_pwmat.py
+++ b/test/interface/test_pwmat.py
@@ -32,3 +32,4 @@ def test_magmom():
     assert cells.isclose(cell, cell_ref)
     diff_mag = cell_ref.magnetic_moments - np.array([1] * 8)
     assert (np.abs(diff_mag) < 1e-5).all()
+


### PR DESCRIPTION
Adapted to new version

 The latest phonopy  seems  not to support generating magnetic of  supercell from magnetic information in unit cells

here improve a function  that writing of magnetic moments and non-collinear magnetic moments form Tag MAGMOM for pwmat