### PR TITLE
Allow for `pip install phonopy[plot]` to get plotting dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ def main(build_dir):
             "h5py>=3.0",
             "spglib>=2.3",
         ],
-        extras_require={"cp2k": ["cp2k-input-tools"]},
+        extras_require={"cp2k": ["cp2k-input-tools"], "plot": ["seekpath"]},
         provides=["phonopy"],
         scripts=scripts_phonopy,
         ext_modules=_get_extensions(build_dir),


### PR DESCRIPTION
Right now, if one wants to use the band structure plotting utilities, seekpath needs to be manually installed. To help with this and to aid in CI, it would be convenient to support a shorthand of `pip install phonopy[plot]` (or similar) to install the optional dependencies for plotting. This would also allow phonopy to restrict versions of `seekpath` if incompatibilities ever arose.