### PR TITLE
Specify data type for the entropy array

### DIFF
--- a/phonopy/qha/core.py
+++ b/phonopy/qha/core.py
@@ -266,7 +266,7 @@ class QHA:
             self._electronic_energies += self._volumes * pressure / EVAngstromToGPa
         self._all_temperatures = np.array(temperatures)
         self._cv = np.array(cv)
-        self._entropy = np.array(entropy)
+        self._entropy = np.array(entropy, dtype="float64")
         self._fe_phonon = np.array(fe_phonon) / EvTokJmol
 
         self._eos = get_eos(eos)


### PR DESCRIPTION
This solves a issue I encountered, when reading thermal properties from a yaml file; the numbers in the array of the entropy are read as strings for some reason, and this collides with numpy at some point. I would get the following error otherwise:

```
Traceback (most recent call last):
  File "/home/---/QHA/phonopy-qha.py", line 321, in <module>
    main(get_options())
  File "/home/---/QHA/phonopy-qha.py", line 253, in main
    phonopy_qha = PhonopyQHA(
                  ^^^^^^^^^^^
  File "/home/---/.cache/pypoetry/virtualenvs/---W3b-Z9Lh-py3.11/lib/python3.11/site-packages/phonopy/api_qha.py", line 128, in __init__
    self._qha.run(verbose=verbose)
  File "/home/---/.cache/pypoetry/virtualenvs/----W3b-Z9Lh-py3.11/lib/python3.11/site-packages/phonopy/qha/core.py", line 408, in run
    self._set_heat_capacity_P_polyfit()
  File "/home/---/.cache/pypoetry/virtualenvs/----W3b-Z9Lh-py3.11/lib/python3.11/site-packages/phonopy/qha/core.py", line 1120, in _set_heat_capacity_P_polyfit
    parameters = np.polyfit(self._volumes, self._entropy[j], 4)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/---/.cache/pypoetry/virtualenvs/----W3b-Z9Lh-py3.11/lib/python3.11/site-packages/numpy/lib/polynomial.py", line 631, in polyfit
    y = NX.asarray(y) + 0.0
        ~~~~~~~~~~~~~~^~~~~
numpy.core._exceptions._UFuncNoLoopError: ufunc 'add' did not contain a loop with signature matching types (dtype('<U32'), dtype('float64')) -> None
```