### PR TITLE
Initialize variable e0

### DIFF
--- a/phonopy/qha/core.py
+++ b/phonopy/qha/core.py
@@ -523,6 +523,7 @@ class QHA:
                 selected_volumes.append(self._equiv_volumes[i])
                 selected_energies.append(self._equiv_energies[i])
 
+        e0 = 0
         for i, t in enumerate(self._temperatures[: self._len]):
             if t >= 298:
                 if i > 0:
@@ -917,6 +918,7 @@ class QHA:
                 selected_volumes.append(self._equiv_volumes[i])
                 selected_energies.append(self._equiv_energies[i])
 
+        e0 = 0
         for i, t in enumerate(self._temperatures[: self._len]):
             if t >= 298:
                 if i > 0:


### PR DESCRIPTION
This repairs the following error I encountered when running phonopy-qha:
```
Traceback (most recent call last):
  File "/home/---/QHA/phonopy-qha.py", line 321, in <module>
    main(get_options())
  File "/home/---/QHA/phonopy-qha.py", line 310, in main
    phonopy_qha.write_helmholtz_volume_fitted(thin_number=args.thin_number)
  File "/home/---/.cache/pypoetry/virtualenvs/----W3b-Z9Lh-py3.11/lib/python3.11/site-packages/phonopy/api_qha.py", line 274, in write_helmholtz_volume_fitted
    self._qha.write_helmholtz_volume_fitted(thin_number, filename=filename)
  File "/home/---/.cache/pypoetry/virtualenvs/----W3b-Z9Lh-py3.11/lib/python3.11/site-packages/phonopy/qha/core.py", line 530, in write_helmholtz_volume_fitted
    e0 *= _energy_plot_factor
    ^^
UnboundLocalError: cannot access local variable 'e0' where it is not associated with a value
```