### PR TITLE
Fix: non-collinear mag missing in supercells generated by using abacus

### DIFF
--- a/phonopy/interface/abacus.py
+++ b/phonopy/interface/abacus.py
@@ -286,11 +286,21 @@ def get_abacus_structure(atoms, pps, orbitals=None, abfs=None):
         line.append(f"{elem}\n{0}\n{numbers[i]}")
         for j in range(index, index + numbers[i]):
             if atoms.magnetic_moments is not None:
-                line_part = " ".join(_list_elem2str(atoms.scaled_positions[j])) + " 1 1 1"
+                line_part = (
+                    " ".join(_list_elem2str(atoms.scaled_positions[j])) + " 1 1 1"
+                )
                 # Add the magnetic moments part
                 mag_mom = atoms.magnetic_moments[j]
                 if len(mag_mom) == 3:  # If three components
-                    line_part += " mag " + " " + str(mag_mom[0]) + " " + str(mag_mom[1]) + " " + str(mag_mom[2])
+                    line_part += (
+                        " mag "
+                        + " "
+                        + str(mag_mom[0])
+                        + " "
+                        + str(mag_mom[1])
+                        + " "
+                        + str(mag_mom[2])
+                    )
                 else:  # If single value
                     line_part += " mag " + str(mag_mom)
                 # Append the completed line

--- a/phonopy/interface/abacus.py
+++ b/phonopy/interface/abacus.py
@@ -188,7 +188,7 @@ def read_abacus(filename):
         if m_index:
             atom_magnetism = mags
 
-    magnetic_moments = atom_magnetism if atom_magnetism.all() else None
+    magnetic_moments = atom_magnetism if atom_magnetism.flatten().any() else None
 
     # to ase
     if atom_pos_type == "Direct":
@@ -286,13 +286,15 @@ def get_abacus_structure(atoms, pps, orbitals=None, abfs=None):
         line.append(f"{elem}\n{0}\n{numbers[i]}")
         for j in range(index, index + numbers[i]):
             if atoms.magnetic_moments is not None:
-                line.append(
-                    " ".join(_list_elem2str(atoms.scaled_positions[j]))
-                    + " "
-                    + "1 1 1"
-                    + " mag "
-                    + f"{atoms.magnetic_moments[j]}"
-                )
+                line_part = " ".join(_list_elem2str(atoms.scaled_positions[j])) + " 1 1 1"
+                # Add the magnetic moments part
+                mag_mom = atoms.magnetic_moments[j]
+                if len(mag_mom) == 3:  # If three components
+                    line_part += " mag " + " " + str(mag_mom[0]) + " " + str(mag_mom[1]) + " " + str(mag_mom[2])
+                else:  # If single value
+                    line_part += " mag " + str(mag_mom)
+                # Append the completed line
+                line.append(line_part)
             else:
                 line.append(
                     " ".join(_list_elem2str(atoms.scaled_positions[j])) + " " + "1 1 1"


### PR DESCRIPTION
Dear Prof. Togo,

This is a PR to fix a bug with the abacus interface. We found that in generating supercells with non-collinear magnetism setting, the resulting STRU files lack mag info. This PR is to fix this bug.

This PR can be reviewed by @1041176461 

Thanks.