### PR TITLE
Package py.typed with code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ PHONOPY_USE_OMP = {env="PHONOPY_USE_OMP", default="ON"}
 [tool.setuptools_scm]
 write_to = "phonopy/_version.py"
 
+[tool.setuptools.package-data]
+phonopy = ["py.typed"]
+
 [tool.ruff]
 line-length = 88
 lint.select = [


### PR DESCRIPTION
In #409, I added a `py.typed` file, but I forgot to ensure that it is packaged with the built package. I have added the py.typed as package-data to `pyproject.toml`. CC @atztogo. Let me know if you'd prefer this in `MANIFEST` though.