### PR TITLE
Address `spglib` dict interface `DeprecationWarnings`

### DIFF
--- a/phonopy/cui/phonopy_script.py
+++ b/phonopy/cui/phonopy_script.py
@@ -1995,8 +1995,8 @@ def main(**argparse_control):
         if phonon.unitcell.magnetic_moments is None:
             print("Spacegroup: %s" % phonon.symmetry.get_international_table())
         elif phonon.symmetry.dataset is not None:
-            uni_number = phonon.symmetry.dataset["uni_number"]
-            msg_type = phonon.symmetry.dataset["msg_type"]
+            uni_number = phonon.symmetry.dataset.uni_number
+            msg_type = phonon.symmetry.dataset.msg_type
             print(f"Magnetic space group UNI number: {uni_number}")
             print(f"Type-{msg_type} magnetic space group")
         print(

--- a/phonopy/interface/phonopy_yaml.py
+++ b/phonopy/interface/phonopy_yaml.py
@@ -465,10 +465,10 @@ class PhonopyYamlDumperBase(ABC):
                 lines.append("")
             else:
                 lines.append("space_group:")
-                spg_type = dataset["international"]
+                spg_type = dataset.international
                 lines.append(f'  type: "{spg_type}"')
-                lines.append(f'  number: {dataset["number"]}')
-                hall_symbol = dataset["hall"]
+                lines.append(f"  number: {dataset.number}")
+                hall_symbol = dataset.hall
                 if '"' in hall_symbol:
                     hall_symbol = hall_symbol.replace('"', '\\"')
                 lines.append(f'  Hall_symbol: "{hall_symbol}"')

--- a/phonopy/phonon/irreps.py
+++ b/phonopy/phonon/irreps.py
@@ -91,7 +91,7 @@ class IrReps:
             self._primitive, symprec=self._symprec
         ).dataset
 
-        if not is_primitive_cell(self._symmetry_dataset["rotations"]):
+        if not is_primitive_cell(self._symmetry_dataset.rotations):
             raise RuntimeError(
                 "Non-primitve cell is used. Your unit cell may be transformed to "
                 "a primitive cell by PRIMITIVE_AXIS tag."
@@ -180,7 +180,7 @@ class IrReps:
     @property
     def eigenvectors(self):
         """Return eigenvectors."""
-        return self._eigvecs
+        return self._eig_vecs
 
     def get_eigenvectors(self):
         """Return eigenvectors."""
@@ -276,14 +276,14 @@ class IrReps:
             dm.run(self._q, q_direction=self._nac_q_direction)
         else:
             dm.run(self._q)
-        eigvals, self._eigvecs = np.linalg.eigh(dm.dynamical_matrix)
-        self._freqs = np.sqrt(abs(eigvals)) * np.sign(eigvals) * self._factor
+        eig_vals, self._eig_vecs = np.linalg.eigh(dm.dynamical_matrix)
+        self._freqs = np.sqrt(abs(eig_vals)) * np.sign(eig_vals) * self._factor
 
     def _get_rotations_at_q(self):
         rotations_at_q = []
         trans_at_q = []
         for r, t in zip(
-            self._symmetry_dataset["rotations"], self._symmetry_dataset["translations"]
+            self._symmetry_dataset.rotations, self._symmetry_dataset.translations
         ):
             diff = np.dot(self._q, r) - self._q
             if (abs(diff - np.rint(diff)) < self._symprec).all():
@@ -297,8 +297,8 @@ class IrReps:
 
     def _get_conventional_rotations(self):
         rotations = self._rotations_at_q.copy()
-        pointgroup_symbol = self._symmetry_dataset["pointgroup"]
-        transformation_matrix = self._symmetry_dataset["transformation_matrix"]
+        pointgroup_symbol = self._symmetry_dataset.pointgroup
+        transformation_matrix = self._symmetry_dataset.transformation_matrix
         conventional_rotations = self._transform_rotations(
             transformation_matrix, rotations
         )
@@ -351,7 +351,7 @@ class IrReps:
         return matrix
 
     def _get_irreps(self):
-        eigvecs = self._eigvecs.T
+        eigvecs = self._eig_vecs.T
         irrep = []
         for band_indices in self._degenerate_sets:
             irrep_Rs = []

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -1751,8 +1751,8 @@ def guess_primitive_matrix(unitcell: PhonopyAtoms, symprec: float = 1e-5):
         raise RuntimeError(msg)
 
     dataset = spglib.get_symmetry_dataset(unitcell.totuple(), symprec=symprec)
-    tmat = dataset["transformation_matrix"]
-    centring = dataset["international"][0]
+    tmat = dataset.transformation_matrix
+    centring = dataset.international[0]
     pmat = get_primitive_matrix_by_centring(centring)
     return np.array(np.dot(np.linalg.inv(tmat), pmat), dtype="double", order="C")
 
@@ -1796,9 +1796,9 @@ def estimate_supercell_matrix(spglib_dataset, max_num_atoms=120, max_iter=100):
         Multiplicities for a, b, c basis vectors, respectively.
 
     """
-    spg_num = spglib_dataset["number"]
-    num_atoms = len(spglib_dataset["std_types"])
-    lengths = get_cell_parameters(spglib_dataset["std_lattice"])
+    spg_num = spglib_dataset.number
+    num_atoms = len(spglib_dataset.std_types)
+    lengths = get_cell_parameters(spglib_dataset.std_lattice)
     if spg_num <= 74:  # Triclinic, monoclinic, and orthorhombic
         multi = _get_multiplicity_abc(
             num_atoms, lengths, max_num_atoms, max_iter=max_iter

--- a/phonopy/structure/grid_points.py
+++ b/phonopy/structure/grid_points.py
@@ -533,7 +533,7 @@ class GeneralizedRegularGridPoints:
         self._generate_grid_points()
         self._generate_q_points()
         self._reciprocal_operations = get_reciprocal_operations(
-            self._sym_dataset["rotations"],
+            self._sym_dataset.rotations,
             self._transformation_matrix,
             self._snf.D,
             self._snf.Q,
@@ -586,15 +586,15 @@ class GeneralizedRegularGridPoints:
         self._snf.run()
 
     def _set_grid_matrix_by_std_primitive_cell(self, cell, length):
-        """Grid generating matrix based on standeardized primitive cell."""
-        tmat = self._sym_dataset["transformation_matrix"]
-        centring = self._sym_dataset["international"][0]
+        """Grid generating matrix based on standardized primitive cell."""
+        tmat = self._sym_dataset.transformation_matrix
+        centring = self._sym_dataset.international[0]
         pmat = get_primitive_matrix_by_centring(centring)
         conv_lat = np.dot(np.linalg.inv(tmat).T, cell.cell)
         num_cells = np.prod(length2mesh(length, conv_lat))
         self._mesh_numbers = estimate_supercell_matrix(
             self._sym_dataset,
-            max_num_atoms=num_cells * len(self._sym_dataset["std_types"]),
+            max_num_atoms=num_cells * len(self._sym_dataset.std_types),
         )
         inv_pmat = np.linalg.inv(pmat)
         inv_pmat_int = np.rint(inv_pmat).astype(int)
@@ -610,7 +610,7 @@ class GeneralizedRegularGridPoints:
 
     def _set_grid_matrix_by_input_cell(self, input_cell, length):
         """Grid generating matrix based on input cell."""
-        pointgroup = get_pointgroup(self._sym_dataset["rotations"])
+        pointgroup = get_pointgroup(self._sym_dataset.rotations)
         # tmat: From input lattice to point group preserving lattice
         tmat = pointgroup[2]
         lattice = np.dot(input_cell.cell.T, tmat).T

--- a/phonopy/structure/symmetry.py
+++ b/phonopy/structure/symmetry.py
@@ -207,7 +207,7 @@ class Symmetry:
 
         Returns
         -------
-        spglib_dataset["equivalent_atoms"]
+        spglib_dataset.equivalent_atoms
         e.g.,
             [0, 0, 0, 0, 4, 4, 4, 4]
 
@@ -330,26 +330,26 @@ class Symmetry:
     def _set_symmetry_dataset(self):
         self._dataset = spglib.get_symmetry_dataset(self._cell.totuple(), self._symprec)
         self._symmetry_operations = {
-            "rotations": self._dataset["rotations"],
-            "translations": self._dataset["translations"],
+            "rotations": self._dataset.rotations,
+            "translations": self._dataset.translations,
         }
         self._international_table = "%s (%d)" % (
-            self._dataset["international"],
-            self._dataset["number"],
+            self._dataset.international,
+            self._dataset.number,
         )
-        self._wyckoff_letters = self._dataset["wyckoffs"]
+        self._wyckoff_letters = self._dataset.wyckoffs
 
-        self._map_atoms = self._dataset["equivalent_atoms"]
+        self._map_atoms = self._dataset.equivalent_atoms
 
     def _set_symmetry_operations_with_magmoms(self):
         self._dataset = spglib.get_magnetic_symmetry_dataset(
             self._cell.totuple(), symprec=self._symprec
         )
         self._symmetry_operations = {
-            "rotations": self._dataset["rotations"],
-            "translations": self._dataset["translations"],
+            "rotations": self._dataset.rotations,
+            "translations": self._dataset.translations,
         }
-        self._map_atoms = self._dataset["equivalent_atoms"]
+        self._map_atoms = self._dataset.equivalent_atoms
 
     def _set_independent_atoms(self):
         indep_atoms = []

--- a/test/interface/test_lammps.py
+++ b/test/interface/test_lammps.py
@@ -52,7 +52,7 @@ def _assert_LammpsStructure(cell: PhonopyAtoms, symbol: str, helper_methods):
     phyml = read_phonopy_yaml(io.StringIO(phonopy_atoms[symbol]))
     helper_methods.compare_cells_with_order(cell, phyml.unitcell)
     symmetry = Symmetry(phyml.unitcell)
-    assert symmetry.dataset["number"] == 194
+    assert symmetry.dataset.number == 194
 
 
 def test_LammpsStructureDumper(primcell_nacl: PhonopyAtoms, helper_methods):

--- a/test/phonon/test_irreps.py
+++ b/test/phonon/test_irreps.py
@@ -1187,7 +1187,7 @@ def _load_data(data_str):
 
 
 def _check_char_sum(phonon: Phonopy, qpoints: list):
-    print("space-group number:", phonon.symmetry.dataset["number"])
+    print("space-group number:", phonon.symmetry.dataset.number)
 
     for q in qpoints:
         phonon.set_irreps(q)


### PR DESCRIPTION
```py
spglib.py:115: DeprecationWarning: dict interface (SpglibDataset['international']) is deprecated.Use attribute interface ({self.__class__.__name__}.{key}) instead
spglib.py:115: DeprecationWarning: dict interface (SpglibDataset['transformation_matrix']) is deprecated.Use attribute interface ({self.__class__.__name__}.{key}) instead
...
```

hope i didn't miss any. the amount of `DeprecationWarnings` i'm seeing locally went from 30 to 6 so i may have missed some but without a stacktrace, it's hard to trace them