### PR TITLE
Spglib < v2.5 treatment after #413

### DIFF
--- a/phonopy/cui/phonopy_script.py
+++ b/phonopy/cui/phonopy_script.py
@@ -1704,7 +1704,7 @@ def _get_cell_info(
     )
 
     # Show primitive matrix overwrite message
-    phpy_yaml: PhonopyYaml = cell_info["phonopy_yaml"]
+    phpy_yaml: PhonopyYaml = cell_info.get("phonopy_yaml")
     if phpy_yaml is not None:
         yaml_filename = cell_info["optional_structure_info"][0]
         pmat_in_settings = _get_primitive_matrix(

--- a/phonopy/interface/phonopy_yaml.py
+++ b/phonopy/interface/phonopy_yaml.py
@@ -460,8 +460,8 @@ class PhonopyYamlDumperBase(ABC):
         if dataset is not None:
             if "uni_number" in dataset:
                 lines.append("magnetic_space_group:")
-                lines.append(f'  uni_number: {dataset["uni_number"]}')
-                lines.append(f'  msg_type: {dataset["msg_type"]}')
+                lines.append(f"  uni_number: {dataset.uni_number}")
+                lines.append(f"  msg_type: {dataset.msg_type}")
                 lines.append("")
             else:
                 lines.append("space_group:")

--- a/phonopy/interface/phonopy_yaml.py
+++ b/phonopy/interface/phonopy_yaml.py
@@ -458,12 +458,13 @@ class PhonopyYamlDumperBase(ABC):
 
         dataset = self._data.symmetry.dataset
         if dataset is not None:
-            if "uni_number" in dataset:
+            try:
+                uni_number = dataset.uni_number
                 lines.append("magnetic_space_group:")
-                lines.append(f"  uni_number: {dataset.uni_number}")
+                lines.append(f"  uni_number: {uni_number}")
                 lines.append(f"  msg_type: {dataset.msg_type}")
                 lines.append("")
-            else:
+            except AttributeError:
                 lines.append("space_group:")
                 spg_type = dataset.international
                 lines.append(f'  type: "{spg_type}"')

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -44,6 +44,7 @@ import spglib
 
 from phonopy.structure.atoms import PhonopyAtoms
 from phonopy.structure.snf import SNF3x3
+from phonopy.utils import get_dot_access_dataset
 
 
 class Supercell(PhonopyAtoms):
@@ -1750,7 +1751,9 @@ def guess_primitive_matrix(unitcell: PhonopyAtoms, symprec: float = 1e-5):
         msg = "Can not be used with the unit cell having magnetic moments."
         raise RuntimeError(msg)
 
-    dataset = spglib.get_symmetry_dataset(unitcell.totuple(), symprec=symprec)
+    dataset = get_dot_access_dataset(
+        spglib.get_symmetry_dataset(unitcell.totuple(), symprec=symprec)
+    )
     tmat = dataset.transformation_matrix
     centring = dataset.international[0]
     pmat = get_primitive_matrix_by_centring(centring)

--- a/phonopy/structure/grid_points.py
+++ b/phonopy/structure/grid_points.py
@@ -58,7 +58,7 @@ from phonopy.structure.symmetry import (
     get_lattice_vector_equivalence,
     get_pointgroup_operations,
 )
-from phonopy.utils import similarity_transformation
+from phonopy.utils import get_dot_access_dataset, similarity_transformation
 from phonopy.version import __version__
 
 
@@ -577,7 +577,9 @@ class GeneralizedRegularGridPoints:
 
     def _prepare(self, cell, length, symprec):
         """Define grid generating matrix and run the SNF."""
-        self._sym_dataset = get_symmetry_dataset(cell.totuple(), symprec=symprec)
+        self._sym_dataset = get_dot_access_dataset(
+            get_symmetry_dataset(cell.totuple(), symprec=symprec)
+        )
         if self._suggest:
             self._set_grid_matrix_by_std_primitive_cell(cell, length)
         else:

--- a/phonopy/structure/symmetry.py
+++ b/phonopy/structure/symmetry.py
@@ -48,7 +48,7 @@ from phonopy.structure.cells import (
     get_primitive,
     get_supercell,
 )
-from phonopy.utils import similarity_transformation
+from phonopy.utils import get_dot_access_dataset, similarity_transformation
 
 
 class Symmetry:
@@ -328,7 +328,10 @@ class Symmetry:
         return np.array(site_symmetries, dtype="intc")
 
     def _set_symmetry_dataset(self):
-        self._dataset = spglib.get_symmetry_dataset(self._cell.totuple(), self._symprec)
+        self._dataset = get_dot_access_dataset(
+            spglib.get_symmetry_dataset(self._cell.totuple(), self._symprec)
+        )
+
         self._symmetry_operations = {
             "rotations": self._dataset.rotations,
             "translations": self._dataset.translations,
@@ -342,8 +345,10 @@ class Symmetry:
         self._map_atoms = self._dataset.equivalent_atoms
 
     def _set_symmetry_operations_with_magmoms(self):
-        self._dataset = spglib.get_magnetic_symmetry_dataset(
-            self._cell.totuple(), symprec=self._symprec
+        self._dataset = get_dot_access_dataset(
+            spglib.get_magnetic_symmetry_dataset(
+                self._cell.totuple(), symprec=self._symprec
+            )
         )
         self._symmetry_operations = {
             "rotations": self._dataset.rotations,

--- a/phonopy/utils.py
+++ b/phonopy/utils.py
@@ -57,8 +57,4 @@ def get_dot_access_dataset(dataset):
     else:
         from types import SimpleNamespace
 
-        class MySimpleNamespace(SimpleNamespace):
-            def __contains__(self, key):
-                return key in self.__dict__
-
-        return MySimpleNamespace(**dataset)
+        return SimpleNamespace(**dataset)

--- a/phonopy/utils.py
+++ b/phonopy/utils.py
@@ -34,9 +34,31 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from importlib.metadata import version
+
 import numpy as np
+from packaging.version import Version
 
 
 def similarity_transformation(rot, mat):
     """Similarity transformation by R x M x R^-1."""
     return np.dot(rot, np.dot(mat, np.linalg.inv(rot)))
+
+
+def get_dot_access_dataset(dataset):
+    """Return dataset with dot access.
+
+    From spglib 2.5, dataset is returned as dataclass.
+    To emulate it for older versions, this function is used.
+
+    """
+    if Version(version("spglib")) >= Version("2.5"):
+        return dataset
+    else:
+        from types import SimpleNamespace
+
+        class MySimpleNamespace(SimpleNamespace):
+            def __contains__(self, key):
+                return key in self.__dict__
+
+        return MySimpleNamespace(**dataset)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -161,6 +161,7 @@ def ph_nacl_rd_symfc() -> Phonopy:
 
     """
     pytest.importorskip("symfc")
+    pytest.importorskip("spglib", minversion="2.5")
 
     yaml_filename = cwd / "phonopy_params_NaCl-rd.yaml.xz"
     return phonopy.load(


### PR DESCRIPTION
At #413, spglib dataset in phonopy is dot-accessed since it became dataclass but not dict.

Tentatively `get_dot_access_dataset` was implemented. When dict is given, this function returns a SimpleNamespace instance to mimic the dot-access.

symfc still uses old style spglib dataset access. The test using symfc is made to run only spglib >=2.5.