### PR TITLE
add filename arg to write yaml for mesh and bs

### DIFF
--- a/phonopy/api_gruneisen.py
+++ b/phonopy/api_gruneisen.py
@@ -113,9 +113,9 @@ class PhonopyGruneisen:
         """Write mesh sampling calculation results to file in yaml."""
         self._mesh.write_yaml(filename=filename)
 
-    def write_hdf5_mesh(self):
+    def write_hdf5_mesh(self, filename="gruneisen_mesh.hdf5"):
         """Write mesh sampling calculation results to file in hdf5."""
-        self._mesh.write_hdf5()
+        self._mesh.write_hdf5(filename=filename)
 
     def plot_mesh(
         self, cutoff_frequency=None, color_scheme=None, marker="o", markersize=None

--- a/phonopy/api_gruneisen.py
+++ b/phonopy/api_gruneisen.py
@@ -109,9 +109,9 @@ class PhonopyGruneisen:
                 self._mesh.get_gruneisen(),
             )
 
-    def write_yaml_mesh(self):
+    def write_yaml_mesh(self, filename="gruneisen_mesh.yaml"):
         """Write mesh sampling calculation results to file in yaml."""
-        self._mesh.write_yaml()
+        self._mesh.write_yaml(filename=filename)
 
     def write_hdf5_mesh(self):
         """Write mesh sampling calculation results to file in hdf5."""
@@ -159,9 +159,9 @@ class PhonopyGruneisen:
             band.get_gruneisen(),
         )
 
-    def write_yaml_band_structure(self):
+    def write_yaml_band_structure(self, filename="gruneisen_band.yaml"):
         """Write band structure calculation results to file in yaml."""
-        self._band_structure.write_yaml()
+        self._band_structure.write_yaml(filename=filename)
 
     def plot_band_structure(self, epsilon=1e-4, color_scheme=None):
         """Return pyplot of band structure calculation results."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "matplotlib>=2.2.2",
     "h5py>=3.0",
     "spglib>=2.3",
-    "scipy>=1.14.0",
 ]
 license = { file = "LICENSE" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "matplotlib>=2.2.2",
     "h5py>=3.0",
     "spglib>=2.3",
+    "scipy>=1.14.0",
 ]
 license = { file = "LICENSE" }
 


### PR DESCRIPTION
Closes #336 

# Changes
Added filename arg to `write_yaml_mesh `and `write_yaml_band_structure ` methods of `PhonopyGruneisen` class. Allows users to modify file names when saving these yaml and hdf5 files when using gruneisen python api