### PR TITLE
Remove symfc dependency to support windows build

### DIFF
--- a/c/_phonopy.cpp
+++ b/c/_phonopy.cpp
@@ -140,7 +140,8 @@ void py_get_dynamical_matrices_with_dd_openmp_over_qpoints(
     born = (double(*)[3][3])py_born.data();
     dielectric = (double(*)[3])py_dielectric.data();
     reciprocal_lattice = (double(*)[3])py_reciprocal_lattice.data();
-    if (use_Wang_NAC) {
+
+    if (use_Wang_NAC || (!is_nac)) {
         positions = NULL;
         dd_q0 = NULL;
         G_list = NULL;
@@ -151,18 +152,13 @@ void py_get_dynamical_matrices_with_dd_openmp_over_qpoints(
         G_list = (double(*)[3])py_G_list.data();
         n_Gpoints = py_G_list.shape(0);
     }
-    if (is_nac_q_zero) {
+
+    if (is_nac_q_zero || (!is_nac)) {
         q_direction = NULL;
     } else {
         q_direction = (double *)py_q_direction.data();
     }
-    if (!is_nac) {
-        positions = NULL;
-        dd_q0 = NULL;
-        G_list = NULL;
-        n_Gpoints = 0;
-        q_direction = NULL;
-    }
+
     num_patom = py_p2s_map.shape(0);
     num_satom = py_s2p_map.shape(0);
 
@@ -301,8 +297,7 @@ void py_get_thermal_properties(nb::ndarray<> py_thermal_props,
                                nb::ndarray<> py_temperatures,
                                nb::ndarray<> py_frequencies,
                                nb::ndarray<> py_weights,
-                               double cutoff_frequency,
-                               int classical) {
+                               double cutoff_frequency, int classical) {
     double *temperatures;
     double *freqs;
     double *thermal_props;

--- a/c/dynmat.c
+++ b/c/dynmat.c
@@ -159,10 +159,9 @@ long dym_dynamical_matrices_with_dd_openmp_over_qpoints(
 #pragma omp parallel for
 #endif
         for (i = 0; i < n_qpoints; i++) {
-            dym_get_dynamical_matrix_at_q(dynamical_matrices + adrs_shift * i,
-                                          num_patom, num_satom, fc, qpoints[i],
-                                          svecs, multi, masses, s2p_map,
-                                          p2s_map, charge_sum, 0);
+            dym_get_dynamical_matrix_at_q(
+                dynamical_matrices + adrs_shift * i, num_patom, num_satom, fc,
+                qpoints[i], svecs, multi, masses, s2p_map, p2s_map, NULL, 0);
             if (dd_q0) {  // NAC by Gonze and Lee if dd_in is not NULL
                 add_dynmat_dd_at_q(dynamical_matrices + adrs_shift * i,
                                    qpoints[i], fc, positions, num_patom, masses,

--- a/c/dynmat.c
+++ b/c/dynmat.c
@@ -87,6 +87,14 @@ static void transform_dynmat_to_fc_ij(
     const long *fc_index_map, const long num_patom, const long num_satom);
 static void get_q_cart(double q_cart[3], const double q[3],
                        const double reciprocal_lattice[3][3]);
+static void get_dynmat_want(
+    double (*dynamical_matrices)[2], const double qpoint[3], const double *fc,
+    const double (*svecs)[3], const long (*multi)[2], const long num_patom,
+    const long num_satom, const double *masses, const long *p2s_map,
+    const long *s2p_map, const double (*born)[3][3],
+    const double dielectric[3][3], const double (*reciprocal_lattice)[3],
+    const double *q_direction, const double *q_dir_cart,
+    const double nac_factor, const double q_zero_tolerance);
 
 /// @brief Calculate dynamical matrices with openmp over q-points
 /// use_Wang_NAC: Wang et al.
@@ -105,15 +113,12 @@ long dym_dynamical_matrices_with_dd_openmp_over_qpoints(
     const double (*dd_q0)[2], const double (*G_list)[3],
     const long num_G_points, const double lambda, const long use_Wang_NAC) {
     long i, n, adrs_shift;
-    double(*charge_sum)[3][3];
-    double q_cart[3];
     double *q_dir_cart;
-    double q_norm, q_zero_tolerance;
+    double q_zero_tolerance;
 
-    charge_sum = NULL;
+    q_zero_tolerance = 1e-5;
     q_dir_cart = NULL;
     adrs_shift = num_patom * num_patom * 9;
-    q_zero_tolerance = 1e-5;
 
     if (q_direction) {
         q_dir_cart = (double *)malloc(sizeof(double) * 3);
@@ -121,38 +126,15 @@ long dym_dynamical_matrices_with_dd_openmp_over_qpoints(
     }
 
     if (use_Wang_NAC) {
-        n = num_satom / num_patom;
 #ifdef _OPENMP
-#pragma omp parallel for private(charge_sum, q_cart, q_norm)
+#pragma omp parallel for
 #endif
         for (i = 0; i < n_qpoints; i++) {
-            get_q_cart(q_cart, qpoints[i], reciprocal_lattice);
-            q_norm = sqrt(q_cart[0] * q_cart[0] + q_cart[1] * q_cart[1] +
-                          q_cart[2] * q_cart[2]);
-            if (q_norm < q_zero_tolerance && q_direction) {
-                charge_sum = (double(*)[3][3])malloc(sizeof(double[3][3]) *
-                                                     num_patom * num_patom);
-                dym_get_charge_sum(
-                    charge_sum, num_patom,
-                    nac_factor / n /
-                        get_dielectric_part(q_direction, dielectric),
-                    q_dir_cart, born);
-            } else if (!(q_norm < q_zero_tolerance)) {
-                charge_sum = (double(*)[3][3])malloc(sizeof(double[3][3]) *
-                                                     num_patom * num_patom);
-                dym_get_charge_sum(
-                    charge_sum, num_patom,
-                    nac_factor / n / get_dielectric_part(q_cart, dielectric),
-                    q_cart, born);
-            }  // (q_norm < q_zero_tolerance && !q_direction) -> no NAC
-            dym_get_dynamical_matrix_at_q(dynamical_matrices + adrs_shift * i,
-                                          num_patom, num_satom, fc, qpoints[i],
-                                          svecs, multi, masses, s2p_map,
-                                          p2s_map, charge_sum, 0);
-            if (charge_sum) {
-                free(charge_sum);
-                charge_sum = NULL;
-            }
+            get_dynmat_want(dynamical_matrices + adrs_shift * i, qpoints[i], fc,
+                            svecs, multi, num_patom, num_satom, masses, p2s_map,
+                            s2p_map, born, dielectric, reciprocal_lattice,
+                            q_direction, q_dir_cart, nac_factor,
+                            q_zero_tolerance);
         }
     } else {
 #ifdef _OPENMP
@@ -177,6 +159,57 @@ long dym_dynamical_matrices_with_dd_openmp_over_qpoints(
         q_dir_cart = NULL;
     }
     return 0;
+}
+
+static void get_dynmat_want(
+    double (*dynamical_matrices)[2], const double qpoint[3], const double *fc,
+    const double (*svecs)[3], const long (*multi)[2], const long num_patom,
+    const long num_satom, const double *masses, const long *p2s_map,
+    const long *s2p_map, const double (*born)[3][3],
+    const double dielectric[3][3], const double (*reciprocal_lattice)[3],
+    const double *q_direction, const double *q_dir_cart,
+    const double nac_factor, const double q_zero_tolerance) {
+    double(*charge_sum)[3][3];
+    double q_cart[3];
+    double q_norm;
+    long n;
+
+    charge_sum = NULL;
+    n = num_satom / num_patom;
+
+    get_q_cart(q_cart, qpoint, reciprocal_lattice);
+    q_norm = sqrt(q_cart[0] * q_cart[0] + q_cart[1] * q_cart[1] +
+                  q_cart[2] * q_cart[2]);
+    charge_sum =
+        (double(*)[3][3])malloc(sizeof(double[3][3]) * num_patom * num_patom);
+
+    if (q_norm < q_zero_tolerance) {
+        if (q_direction) {
+            dym_get_charge_sum(
+                charge_sum, num_patom,
+                nac_factor / n / get_dielectric_part(q_dir_cart, dielectric),
+                q_dir_cart, born);
+            dym_get_dynamical_matrix_at_q(
+                dynamical_matrices, num_patom, num_satom, fc, qpoint, svecs,
+                multi, masses, s2p_map, p2s_map, charge_sum, 0);
+
+        } else {
+            dym_get_dynamical_matrix_at_q(dynamical_matrices, num_patom,
+                                          num_satom, fc, qpoint, svecs, multi,
+                                          masses, s2p_map, p2s_map, NULL, 0);
+        }
+    } else {
+        dym_get_charge_sum(
+            charge_sum, num_patom,
+            nac_factor / n / get_dielectric_part(q_cart, dielectric), q_cart,
+            born);
+        dym_get_dynamical_matrix_at_q(dynamical_matrices, num_patom, num_satom,
+                                      fc, qpoint, svecs, multi, masses, s2p_map,
+                                      p2s_map, charge_sum, 0);
+    }
+
+    free(charge_sum);
+    charge_sum = NULL;
 }
 
 static void add_dynmat_dd_at_q(

--- a/phonopy/harmonic/dynamical_matrix.py
+++ b/phonopy/harmonic/dynamical_matrix.py
@@ -1217,15 +1217,17 @@ def run_dynamical_matrix_solver_c(
         ) = gonze_nac_dataset  # Convergence parameter
         fc = gonze_fc
     else:
-        dd_q0 = np.zeros(2)  # dummy value
-        G_list = np.zeros(3)  # dummy value
+        dd_q0 = np.zeros(
+            (len(positions), 3, 3), dtype="double", order="C"
+        )  # dummy value
+        G_list = np.zeros((1, 3), dtype="double", order="C")  # dummy value
         Lambda = 0.0  # dummy value
         fc = dm.force_constants
         use_Wang_NAC = _is_nac and dm.nac_method == "wang"
 
     if nac_q_direction is None:
         is_nac_q_zero = True
-        _nac_q_direction = np.zeros(3)  # dummy variable
+        _nac_q_direction = np.zeros(3, dtype="double")  # dummy variable
     else:
         is_nac_q_zero = False
         _nac_q_direction = np.array(nac_q_direction, dtype="double")
@@ -1233,7 +1235,10 @@ def run_dynamical_matrix_solver_c(
     p2s, s2p = _get_fc_elements_mapping(dm, fc)
 
     dtype_complex = "c%d" % (np.dtype("double").itemsize * 2)
-    dynmat = np.zeros((len(qpoints), len(p2s) * 3, len(p2s) * 3), dtype=dtype_complex)
+    dynmat = np.zeros(
+        (len(qpoints), len(p2s) * 3, len(p2s) * 3), dtype=dtype_complex, order="C"
+    )
+
     phonoc.dynamical_matrices_with_dd_openmp_over_qpoints(
         dynmat.view(dtype="double"),
         _qpoints,

--- a/phonopy/harmonic/dynamical_matrix.py
+++ b/phonopy/harmonic/dynamical_matrix.py
@@ -1203,27 +1203,31 @@ def run_dynamical_matrix_solver_c(
     ) = _extract_params(dm)
 
     use_Wang_NAC = False
-    if _is_nac and dm.nac_method == "gonze":
-        gonze_nac_dataset = dm.Gonze_nac_dataset
-        if gonze_nac_dataset[0] is None:
-            dm.make_Gonze_nac_dataset()
+    if _is_nac:
+        if dm.nac_method == "gonze":
             gonze_nac_dataset = dm.Gonze_nac_dataset
-        (
-            gonze_fc,  # fc where the dipole-diple contribution is removed.
-            dd_q0,  # second term of dipole-dipole expression.
-            G_cutoff,  # Cutoff radius in reciprocal space. This will not be used.
-            G_list,  # List of G points where d-d interactions are integrated.
-            Lambda,
-        ) = gonze_nac_dataset  # Convergence parameter
-        fc = gonze_fc
+            if gonze_nac_dataset[0] is None:
+                dm.make_Gonze_nac_dataset()
+                gonze_nac_dataset = dm.Gonze_nac_dataset
+            (
+                gonze_fc,  # fc where the dipole-diple contribution is removed.
+                dd_q0,  # second term of dipole-dipole expression.
+                G_cutoff,  # Cutoff radius in reciprocal space. This will not be used.
+                G_list,  # List of G points where d-d interactions are integrated.
+                Lambda,
+            ) = gonze_nac_dataset  # Convergence parameter
+            fc = gonze_fc
+        if dm.nac_method == "wang":
+            use_Wang_NAC = True
+            dd_q0 = np.zeros((len(positions), 3, 3), dtype="double", order="C")
+            G_list = np.zeros((1, 3), dtype="double", order="C")  # dummy value
+            Lambda = 0.0
+            fc = dm.force_constants
     else:
-        dd_q0 = np.zeros(
-            (len(positions), 3, 3), dtype="double", order="C"
-        )  # dummy value
+        dd_q0 = np.zeros((len(positions), 3, 3), dtype="double", order="C")
         G_list = np.zeros((1, 3), dtype="double", order="C")  # dummy value
-        Lambda = 0.0  # dummy value
+        Lambda = 0.0
         fc = dm.force_constants
-        use_Wang_NAC = _is_nac and dm.nac_method == "wang"
 
     if nac_q_direction is None:
         is_nac_q_zero = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "matplotlib>=2.2.2",
     "h5py>=3.0",
     "spglib>=2.3",
-    "symfc>=1.1.7",
 ]
 license = { file = "LICENSE" }
 

--- a/test/cui/test_phonopy_cui.py
+++ b/test/cui/test_phonopy_cui.py
@@ -110,6 +110,8 @@ def test_create_force_sets():
 
 def test_phonopy_load():
     """Test phonopy-load command."""
+    pytest.importorskip("symfc")
+
     # Check sys.exit(0)
     argparse_control = _get_phonopy_load_args(
         cwd / ".." / "phonopy_params_NaCl-1.00.yaml.xz"

--- a/test/phonon/test_mesh.py
+++ b/test/phonon/test_mesh.py
@@ -187,14 +187,9 @@ def test_Mesh_full_fcsym_nonac(ph_nacl_nonac: Phonopy):
     _test_IterMesh(ph_nacl_nonac, freqs_nonac_ref)
 
 
-def test_Mesh_full_fcsym_wang(ph_nacl: Phonopy):
+def test_Mesh_full_fcsym_wang(ph_nacl_wang: Phonopy):
     """Test by NaCl with symmetrizing force constants."""
-    nac_params = ph_nacl.nac_params
-    nac_params["method"] = "wang"
-    ph_nacl.nac_params = nac_params
-    _test_IterMesh(ph_nacl, freqs_full_fcsym_ref_wang)
-    nac_params.pop("method")
-    ph_nacl.nac_params = nac_params
+    _test_IterMesh(ph_nacl_wang, freqs_full_fcsym_ref_wang)
 
 
 def test_Mesh_full_fcsym_si(ph_si: Phonopy):


### PR DESCRIPTION
Symfc crashes by unknown reason on conda-forge windows build. Therefore symfc was dropped from the list of dependent packages.

In addition, this PR includes refactoring of `dynmat.c`. This was made because the windows build crashed in the Wang's NAC method implementation. Though the reason of the crash was not clear, after the refactoring (`private(charge_sum, q_cart, q_norm)` was removed by pushing the calculation into a function), it started working, at least currently.