### PR TITLE
CP2K interface fix angle unit

### DIFF
--- a/phonopy/interface/cp2k.py
+++ b/phonopy/interface/cp2k.py
@@ -112,10 +112,10 @@ def read_cp2k(filename):
 
             alpha, beta, gamma = cp2k_cell.pop("alpha_beta_gamma")
 
-            cos_alpha = np.cos(alpha)
-            cos_beta = np.cos(beta)
-            cos_gamma = np.cos(gamma)
-            sin_gamma = np.sin(gamma)
+            cos_alpha = np.cos(alpha * np.pi / 180.0)
+            cos_beta = np.cos(beta * np.pi / 180.0)
+            cos_gamma = np.cos(gamma * np.pi / 180.0)
+            sin_gamma = np.sin(gamma * np.pi / 180.0)
 
             unit_cell = np.array(
                 [


### PR DESCRIPTION
The default unit for angles is in degrees for the cp2k input file - this pull request fixes this.

cp2k-input-tools converts other units (which you can specify in the input deck) to degrees from my testing, so this should work universally.
