### PR TITLE
Make wheels on ubuntu, ubuntu-arm, macos-arm64, and windows-win32 and -amd64

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -23,13 +23,23 @@ jobs:
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==2.22.0
 
-    - name: Build wheels on non-windows
-      if: ${{ ! startsWith(matrix.os, 'windows') }}
+    - name: Build wheels on ubuntu
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
         git tag v`grep __version__ phonopy/version.py|awk -F'"' '{print($2)}'`
         python -m cibuildwheel --output-dir wheelhouse
       env:
         CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
+        CIBW_BUILD_VERBOSITY: 1
+
+    - name: Build wheels on macos
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      run: |
+        git tag v`grep __version__ phonopy/version.py|awk -F'"' '{print($2)}'`
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "cp39-* pp*"
+        CIBW_ARCHS_MACOS: "x86_64 arm64"
         CIBW_BUILD_VERBOSITY: 1
 
     - name: Build wheels on windows
@@ -42,7 +52,7 @@ jobs:
         Write-Output "The value of version is: $version"
         python -m cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
+        CIBW_SKIP: "cp39-* pp*"
         CIBW_BUILD_VERBOSITY: 1
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,7 +39,7 @@ jobs:
         python -m cibuildwheel --output-dir wheelhouse
       env:
         CIBW_SKIP: "cp39-* pp*"
-        CIBW_ARCHS_MACOS: "x86_64 arm64"
+        # CIBW_ARCHS_MACOS: "x86_64 arm64"
         CIBW_BUILD_VERBOSITY: 1
 
     - name: Build wheels on windows

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest,]
-        # os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -55,7 +54,7 @@ jobs:
     name: Upload to PyPI (test)
     needs: [build_wheels,]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel-test')
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/make-wheel-test' }}
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -73,7 +72,7 @@ jobs:
     name: Upload to PyPI
     needs: [build_wheels,]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel')
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/make-wheel' }}
     steps:
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,9 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,]
+        os: [ubuntu-latest, macos-latest, windows-latest,]
         # os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-
 
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +24,8 @@ jobs:
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==2.22.0
 
-    - name: Build wheels
+    - name: Build wheels on non-windows
+      if: ${{ ! startsWith(matrix.os, 'windows') }}
       run: |
         git tag v`grep __version__ phonopy/version.py|awk -F'"' '{print($2)}'`
         python -m cibuildwheel --output-dir wheelhouse
@@ -33,9 +33,18 @@ jobs:
         CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
         CIBW_BUILD_VERBOSITY: 1
 
-      # to supply options, put them in 'env', like:
-      # env:
-      #   CIBW_SOME_OPTION: value
+    - name: Build wheels on windows
+      if: ${{ startsWith(matrix.os, 'windows') }}
+      run: |
+        $version = Select-String -Path "phonopy\version.py" -Pattern '__version__' | ForEach-Object {
+            ($_ -split '"')[1]
+        }
+        git tag "v$version"
+        Write-Output "The value of version is: $version"
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "cp39-* pp* *_i686 *musllinux*"
+        CIBW_BUILD_VERBOSITY: 1
 
     - uses: actions/upload-artifact@v4
       with:
@@ -44,11 +53,8 @@ jobs:
 
   upload_pypi_test:
     name: Upload to PyPI (test)
-    strategy:
-      matrix:
-        os: [ubuntu-latest,]
     needs: [build_wheels,]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel-test')
     steps:
     - uses: actions/download-artifact@v4
@@ -60,16 +66,13 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
         skip-existing: true
 
   upload_pypi:
     name: Upload to PyPI
-    strategy:
-      matrix:
-        os: [ubuntu-latest,]
     needs: [build_wheels,]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/make-wheel')
     steps:
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
Making wheel for macos-x86_64 failed either on `macos-13` and crosscompiling with `CIBW_ARCHS_MACOS: "x86_64 arm64"` on `macos-latest`.

```
[8/19] /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DNB_COMPACT_ASSERTIONS -I/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/ext/robin_map/include -I/Library/Frameworks/Python.framework/Versions/3.10/include/python3.10 -I/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/include -O3 -DNDEBUG -std=gnu++17 -arch x86_64 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk -mmacosx-version-min=10.9 -fPIC -fvisibility=hidden -fno-strict-aliasing -MD -MT CMakeFiles/nanobind-static.dir/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp.o -MF CMakeFiles/nanobind-static.dir/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp.o.d -o CMakeFiles/nanobind-static.dir/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp.o -c /private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp
    FAILED: CMakeFiles/nanobind-static.dir/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp.o
    /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DNB_COMPACT_ASSERTIONS -I/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/ext/robin_map/include -I/Library/Frameworks/Python.framework/Versions/3.10/include/python3.10 -I/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/include -O3 -DNDEBUG -std=gnu++17 -arch x86_64 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk -mmacosx-version-min=10.9 -fPIC -fvisibility=hidden -fno-strict-aliasing -MD -MT CMakeFiles/nanobind-static.dir/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp.o -MF CMakeFiles/nanobind-static.dir/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp.o.d -o CMakeFiles/nanobind-static.dir/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp.o -c /private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp
    /private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp:[248](https://github.com/phonopy/phonopy/actions/runs/12983635492/job/36205247175#step:6:252):13: error: aligned deallocation function of type 'void (void *, std::align_val_t) noexcept' is only available on macOS 10.13 or newer
                operator delete(p, std::align_val_t(t->align));
                ^
    /private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pip-build-env-1qq_k1f_/overlay/lib/python3.10/site-packages/nanobind/src/nb_type.cpp:248:13: note: if you supply your own aligned allocation functions, use -faligned-allocation to silence this diagnostic
    1 error generated.
```