### PR TITLE
Abacus accuracy in structural parameters fix

### DIFF
--- a/phonopy/interface/abacus.py
+++ b/phonopy/interface/abacus.py
@@ -379,6 +379,6 @@ def _list_elem2str(a):
     """Convert type of list element to str."""
 
     def f_str(x):
-        return f"{x:0<12f}"
+        return f"{x:0<16.12f}"
 
     return list(map(f_str, a))


### PR DESCRIPTION
This PR as written in title fix accuracy issue. Critically important for hexagonal symmetry which is wrongly determined until --tolerance=1e-04 parameter used