### PR TITLE
cp2k interface extension to collect energies if presented

### DIFF
--- a/phonopy/interface/cp2k.py
+++ b/phonopy/interface/cp2k.py
@@ -91,7 +91,7 @@ def parse_set_of_energy_forces2025(num_atoms, forces_filenames, verbose=True):
     """Parse forces from output files."""
     force_sets = []
     energy_sets = []
-    
+
     for i, filename in enumerate(forces_filenames):
         if verbose:
             sys.stdout.write("%d. " % (i + 1))
@@ -115,7 +115,7 @@ def parse_set_of_energy_forces2025(num_atoms, forces_filenames, verbose=True):
                     esc = float(line.split('=')[1])
             energy_sets.append(esc)
 
-    return {"forces": force_sets, 
+    return {"forces": force_sets,
             "supercell_energies": energy_sets,
     }
 
@@ -171,7 +171,7 @@ def parse_set_of_energy_forces2024(num_atoms, forces_filenames, verbose=True):
                     esc = float(line.split('=')[1])
             energy_sets.append(esc)
 
-    return {"forces": force_sets, 
+    return {"forces": force_sets,
             "supercell_energies": energy_sets,
     }
 


### PR DESCRIPTION
This is a part of work on adding support of CP2K for LTC calculations. CP2K stores calculated forces in separate file with .xyz extension. The energies are provided in general output. The energy can be added to .xyz file by external tool (will be provided as a part of example in phono3py) at the end as a single line for example: `TOTEN = -17864.22596726682241`  The value converted to Ev.
 cp2kver function determine if there are energy given at the end of file with forces and append suffix `e`  to version, so `parse_set_of_forces` function can determine if energies provided in output then forces and energies returned by `parse_set_of_energy_forces2025` or `parse_set_of_energy_forces2024` functions as dictionary. 
This approach seem easier than parsing two sets of files separately. And looks safe enough.