### PR TITLE
Default nac_factor and force_to_eVperA parameters for CP2K

### DIFF
--- a/phonopy/interface/calculator.py
+++ b/phonopy/interface/calculator.py
@@ -685,8 +685,9 @@ def get_default_physical_units(interface_mode=None):
         units["force_unit"] = "eV/angstrom"
     elif interface_mode == "cp2k":
         units["factor"] = CP2KToTHz
-        units["nac_factor"] = None  # not implemented
+        units["nac_factor"] = Bohr**2
         units["distance_to_A"] = 1.0
+        units["force_to_eVperA"] = Hartree / Bohr
         units["force_constants_unit"] = "hartree/angstrom.au"
         units["length_unit"] = "angstrom"
         units["force_unit"] = "hartree/au"


### PR DESCRIPTION
These are necessary to convert CP2K units to the one used in `PHONOPY API`. I should recall that `phonopy` deal nothing with CP2K general output file where energy values reported, instead it reads .xyz files with only data on forces. This "traditional way" hard to modify and I'm not sure it's really need to be modified (more over .xyz file provide higher precision values than in general output). The energy can be added using external script which I'm going to upload to phono3py examples repository when finish tests. I think if external tool is used it is better to use eV, instead of Ha units used in CP2K general output. Therefore I would suggest to skip implementing units["energy_to_eV"] and units["energy_unit"] for CP2K until it become really necessary. 