### PR TITLE
Allow necessary info to be passed for file conversion

### DIFF
--- a/phonopy/interface/calculator.py
+++ b/phonopy/interface/calculator.py
@@ -106,8 +106,10 @@ def convert_crystal_structure(
 ):
     """Convert crystal structures between different calculator interfaces.
 
-    optional_structure_info: Some interfaces may take additional information, such as the pseudopotential files for Quantum Espresso ("qe")
-    Pass this info explicitly rather than relying on the info found by `read_crystal_structure`. The type of data depends on the calculator used.
+    optional_structure_info: Some interfaces may take additional information,
+    such as the pseudopotential files for Quantum Espresso ("qe").
+    Pass this info explicitly rather than relying on the info found by `read_crystal_structure`.
+    The type of data depends on the calculator used.
     """
     cell, _ = read_crystal_structure(filename=filename_in, interface_mode=interface_in)
     units_in = get_calculator_physical_units(interface_in)
@@ -157,7 +159,9 @@ def write_crystal_structure(
             pp_filenames = optional_structure_info[1]
         else:
             warnings.warn(
-                "Optional structure information (pp_filenames) is missing\nYou will need to manually add pp filenames to the qe input file."
+                "Optional structure information (pp_filenames) is missing\n\
+                    You will need to manually add pp filenames to the qe input file.",
+                stacklevel=2,
             )
             pp_filenames = None
         qe.write_pwscf(filename, cell, pp_filenames)

--- a/phonopy/interface/calculator.py
+++ b/phonopy/interface/calculator.py
@@ -108,8 +108,7 @@ def convert_crystal_structure(
 
     optional_structure_info: Some interfaces may take additional information,
     such as the pseudopotential files for Quantum Espresso ("qe").
-    Pass this info explicitly rather than relying on the info found by `read_crystal_structure`.
-    The type of data depends on the calculator used.
+    Pass this info explicitly. The type of data depends on the calculator used.
     """
     cell, _ = read_crystal_structure(filename=filename_in, interface_mode=interface_in)
     units_in = get_calculator_physical_units(interface_in)
@@ -140,7 +139,7 @@ def write_crystal_structure(
         Calculator interface such as 'vasp', 'qe', ... Default is None,
         that is equivalent to 'vasp'.
     optional_structure_info : tuple, optional
-        Information returned by the method ``read_crystal_structure``.
+        Information returned by the method `read_crystal_structure`.
         See the docstring. Default is None.
 
     """

--- a/phonopy/interface/calculator.py
+++ b/phonopy/interface/calculator.py
@@ -101,9 +101,11 @@ def get_interface_mode(args_dict):
     return None
 
 
-def convert_crystal_structure(filename_in, interface_in, filename_out, interface_out, optional_structure_info=None):
+def convert_crystal_structure(
+    filename_in, interface_in, filename_out, interface_out, optional_structure_info=None
+):
     """Convert crystal structures between different calculator interfaces.
-    
+
     optional_structure_info: Some interfaces may take additional information, such as the pseudopotential files for Quantum Espresso ("qe")
     Pass this info explicitly rather than relying on the info found by `read_crystal_structure`. The type of data depends on the calculator used.
     """
@@ -112,7 +114,12 @@ def convert_crystal_structure(filename_in, interface_in, filename_out, interface
     units_out = get_calculator_physical_units(interface_out)
     factor = units_in["distance_to_A"] / units_out["distance_to_A"]
     cell.cell = cell.cell * factor
-    write_crystal_structure(filename_out, cell, interface_mode=interface_out, optional_structure_info=optional_structure_info)
+    write_crystal_structure(
+        filename_out,
+        cell,
+        interface_mode=interface_out,
+        optional_structure_info=optional_structure_info,
+    )
 
 
 def write_crystal_structure(
@@ -149,7 +156,9 @@ def write_crystal_structure(
         if optional_structure_info is not None:
             pp_filenames = optional_structure_info[1]
         else:
-            warnings.warn("Optional structure information (pp_filenames) is missing\nYou will need to manually add pp filenames to the qe input file.")
+            warnings.warn(
+                "Optional structure information (pp_filenames) is missing\nYou will need to manually add pp filenames to the qe input file."
+            )
             pp_filenames = None
         qe.write_pwscf(filename, cell, pp_filenames)
 
@@ -159,7 +168,9 @@ def write_crystal_structure(
         if optional_structure_info is not None:
             _, npts, r0s, rmts = optional_structure_info
         else:
-            raise RuntimeError("Optional structure information (_, npts, r0s, rmts) is missing.")
+            raise RuntimeError(
+                "Optional structure information (_, npts, r0s, rmts) is missing."
+            )
         wien2k.write_wein2k(filename, cell, npts, r0s, rmts)
     elif interface_mode == "elk":
         import phonopy.interface.elk as elk
@@ -191,7 +202,9 @@ def write_crystal_structure(
         if optional_structure_info is not None:
             conv_numbers = optional_structure_info[1]
         else:
-            raise RuntimeError("Optional structure information (conv_numbers) is missing.")
+            raise RuntimeError(
+                "Optional structure information (conv_numbers) is missing."
+            )
         crystal.write_crystal(filename, cell, conv_numbers)
     elif interface_mode == "dftbp":
         import phonopy.interface.dftbp as dftbp
@@ -215,7 +228,9 @@ def write_crystal_structure(
         if optional_structure_info is not None:
             speci, restlines = optional_structure_info
         else:
-            raise RuntimeError("Optional structure information (speci, restlines) is missing.")
+            raise RuntimeError(
+                "Optional structure information (speci, restlines) is missing."
+            )
         fleur.write_fleur(filename, cell, speci, 1, restlines)
     elif interface_mode == "abacus":
         import phonopy.interface.abacus as abacus
@@ -225,7 +240,9 @@ def write_crystal_structure(
             orbitals = optional_structure_info[2]
             abfs = optional_structure_info[3]
         else:
-            raise RuntimeError("Optional structure information (pps, orbitals, abfs) is missing.")
+            raise RuntimeError(
+                "Optional structure information (pps, orbitals, abfs) is missing."
+            )
         abacus.write_abacus(filename, cell, pps, orbitals, abfs)
     elif interface_mode == "lammps":
         import phonopy.interface.lammps as lammps

--- a/phonopy/interface/calculator.py
+++ b/phonopy/interface/calculator.py
@@ -101,14 +101,18 @@ def get_interface_mode(args_dict):
     return None
 
 
-def convert_crystal_structure(filename_in, interface_in, filename_out, interface_out):
-    """Convert crystal structures between different calculator interfaces."""
+def convert_crystal_structure(filename_in, interface_in, filename_out, interface_out, optional_structure_info=None):
+    """Convert crystal structures between different calculator interfaces.
+    
+    optional_structure_info: Some interfaces may take additional information, such as the pseudopotential files for Quantum Espresso ("qe")
+    Pass this info explicitly rather than relying on the info found by `read_crystal_structure`. The type of data depends on the calculator used.
+    """
     cell, _ = read_crystal_structure(filename=filename_in, interface_mode=interface_in)
     units_in = get_calculator_physical_units(interface_in)
     units_out = get_calculator_physical_units(interface_out)
     factor = units_in["distance_to_A"] / units_out["distance_to_A"]
     cell.cell = cell.cell * factor
-    write_crystal_structure(filename_out, cell, interface_mode=interface_out)
+    write_crystal_structure(filename_out, cell, interface_mode=interface_out, optional_structure_info=optional_structure_info)
 
 
 def write_crystal_structure(
@@ -142,33 +146,52 @@ def write_crystal_structure(
     elif interface_mode == "qe":
         import phonopy.interface.qe as qe
 
-        pp_filenames = optional_structure_info[1]
+        if optional_structure_info is not None:
+            pp_filenames = optional_structure_info[1]
+        else:
+            warnings.warn("Optional structure information (pp_filenames) is missing\nYou will need to manually add pp filenames to the qe input file.")
+            pp_filenames = None
         qe.write_pwscf(filename, cell, pp_filenames)
 
     elif interface_mode == "wien2k":
         import phonopy.interface.wien2k as wien2k
 
-        _, npts, r0s, rmts = optional_structure_info
+        if optional_structure_info is not None:
+            _, npts, r0s, rmts = optional_structure_info
+        else:
+            raise RuntimeError("Optional structure information (_, npts, r0s, rmts) is missing.")
         wien2k.write_wein2k(filename, cell, npts, r0s, rmts)
     elif interface_mode == "elk":
         import phonopy.interface.elk as elk
 
-        sp_filenames = optional_structure_info[1]
+        if optional_structure_info is not None:
+            sp_filenames = optional_structure_info[1]
+        else:
+            sp_filenames = None
         elk.write_elk(filename, cell, sp_filenames)
     elif interface_mode == "siesta":
         import phonopy.interface.siesta as siesta
 
-        atypes = optional_structure_info[1]
+        if optional_structure_info is not None:
+            atypes = optional_structure_info[1]
+        else:
+            raise RuntimeError("Optional structure information (atypes) is missing.")
         siesta.write_siesta(filename, cell, atypes)
     elif interface_mode == "cp2k":
         import phonopy.interface.cp2k as cp2k
 
-        _, tree = optional_structure_info
+        if optional_structure_info is not None:
+            _, tree = optional_structure_info
+        else:
+            raise RuntimeError("Optional structure information (tree) is missing.")
         cp2k.write_cp2k_by_filename(filename, cell, tree)
     elif interface_mode == "crystal":
         import phonopy.interface.crystal as crystal
 
-        conv_numbers = optional_structure_info[1]
+        if optional_structure_info is not None:
+            conv_numbers = optional_structure_info[1]
+        else:
+            raise RuntimeError("Optional structure information (conv_numbers) is missing.")
         crystal.write_crystal(filename, cell, conv_numbers)
     elif interface_mode == "dftbp":
         import phonopy.interface.dftbp as dftbp
@@ -189,14 +212,20 @@ def write_crystal_structure(
     elif interface_mode == "fleur":
         import phonopy.interface.fleur as fleur
 
-        speci, restlines = optional_structure_info
+        if optional_structure_info is not None:
+            speci, restlines = optional_structure_info
+        else:
+            raise RuntimeError("Optional structure information (speci, restlines) is missing.")
         fleur.write_fleur(filename, cell, speci, 1, restlines)
     elif interface_mode == "abacus":
         import phonopy.interface.abacus as abacus
 
-        pps = optional_structure_info[1]
-        orbitals = optional_structure_info[2]
-        abfs = optional_structure_info[3]
+        if optional_structure_info is not None:
+            pps = optional_structure_info[1]
+            orbitals = optional_structure_info[2]
+            abfs = optional_structure_info[3]
+        else:
+            raise RuntimeError("Optional structure information (pps, orbitals, abfs) is missing.")
         abacus.write_abacus(filename, cell, pps, orbitals, abfs)
     elif interface_mode == "lammps":
         import phonopy.interface.lammps as lammps

--- a/phonopy/scripts/phonopy_calc_convert.py
+++ b/phonopy/scripts/phonopy_calc_convert.py
@@ -50,6 +50,7 @@ def get_options():
         metavar="FILE_IN",
         default=None,
         help="Input crystal structure filename",
+        required=True,
     )
     parser.add_argument(
         "-o",
@@ -57,6 +58,7 @@ def get_options():
         metavar="FILE_OUT",
         default=None,
         help="Output crystal structure filename",
+        required=True,
     )
     parser.add_argument(
         "--calcin",
@@ -64,6 +66,7 @@ def get_options():
         metavar="CALC_IN",
         default=None,
         help="Input calculator format",
+        required=True,
     )
     parser.add_argument(
         "--calcout",
@@ -71,6 +74,7 @@ def get_options():
         metavar="CALC_OUT",
         default=None,
         help="Output calculator format",
+        required=True,
     )
     parser.add_argument(
         "--additional-info",
@@ -94,13 +98,9 @@ def run():
     )
 
     try:
-        _is_file_None(args[0], "input")
         _infile_exist(args[0])
-        _is_file_None(args[2], "output")
         _outfile_exist(args[2])
-        _is_calc_None(args[1], "input")
         _calc_check(args[1])
-        _is_calc_None(args[3], "output")
         _calc_check(args[3])
     except (RuntimeError, FileNotFoundError) as err:
         print("ERROR: %s" % err)
@@ -111,18 +111,6 @@ def run():
 def _calc_check(calc_str):
     if calc_str.lower() not in calculator_info:
         msg = 'Calculator name of "%s" is not supported.' % calc_str
-        raise RuntimeError(msg)
-
-
-def _is_calc_None(calculator, input_or_output):
-    if calculator is None:
-        msg = "Specify %s calculator format." % input_or_output
-        raise RuntimeError(msg)
-
-
-def _is_file_None(filename, input_or_output):
-    if filename is None:
-        msg = "Specify %s filename." % input_or_output
         raise RuntimeError(msg)
 
 

--- a/phonopy/scripts/phonopy_calc_convert.py
+++ b/phonopy/scripts/phonopy_calc_convert.py
@@ -81,7 +81,9 @@ def get_options():
         dest="additional_info",
         metavar="ADDITIONAL_INFO",
         default=None,
-        help="Additional information for the conversion, which is required for some calculators. If not provided when required, an error will be raised.",
+        help="Additional information for the conversion,\
+            which is required for some calculators.\
+                If not provided when required, an error will be raised.",
     )
     return parser.parse_args()
 

--- a/phonopy/scripts/phonopy_calc_convert.py
+++ b/phonopy/scripts/phonopy_calc_convert.py
@@ -72,6 +72,13 @@ def get_options():
         default=None,
         help="Output calculator format",
     )
+    parser.add_argument(
+        "--additional-info",
+        dest="additional_info",
+        metavar="ADDITIONAL_INFO",
+        default=None,
+        help="Additional information for the conversion, which is required for some calculators. If not provided when required, an error will be raised.",
+    )
     return parser.parse_args()
 
 
@@ -83,6 +90,7 @@ def run():
         opts.calculator_in,
         opts.filename_out,
         opts.calculator_out,
+        opts.additional_info,
     )
 
     try:

--- a/test/interface/test_conversion.py
+++ b/test/interface/test_conversion.py
@@ -3,6 +3,7 @@
 import tempfile
 
 import pytest
+import os
 
 from phonopy.interface.calculator import calculator_info, convert_crystal_structure
 
@@ -12,10 +13,10 @@ def test_conversion():
     calcs = calculator_info.keys()
     require_extra_info = ["wien2k", "siesta", "cp2k", "crystal", "fleur", "abacus"]
 
+    parent_dir = os.path.dirname(os.path.abspath(__file__))
     temp = tempfile.NamedTemporaryFile()
     td = tempfile.TemporaryDirectory()
-
-    POSCAR = "../POSCAR_NaCl"
+    POSCAR = os.path.join(parent_dir, "POSCAR_NaCl")
 
     for calc in calcs:
         if calc == "turbomole":

--- a/test/interface/test_conversion.py
+++ b/test/interface/test_conversion.py
@@ -1,15 +1,11 @@
-"""Test Conversion between calculator formats"""
+"""Test Conversion between calculator formats."""
 
-import tempfile
-
-import pytest
-import os
-
+import tempfile, pytest, os
 from phonopy.interface.calculator import calculator_info, convert_crystal_structure
 
 
 def test_conversion():
-    """Calcs that can use extra info are below"""
+    """Calcs that can use extra info are below."""
     calcs = calculator_info.keys()
     require_extra_info = ["wien2k", "siesta", "cp2k", "crystal", "fleur", "abacus"]
 

--- a/test/interface/test_conversion.py
+++ b/test/interface/test_conversion.py
@@ -1,0 +1,28 @@
+"""Test Conversion between calculator formats"""
+
+import tempfile, pytest
+from phonopy.interface.calculator import convert_crystal_structure, calculator_info
+
+
+def test_conversion():
+    """calcs that can use extra info are below"""
+    calcs = calculator_info.keys()
+    require_extra_info = ["wien2k", "siesta", "cp2k", "crystal", "fleur", "abacus"]
+    
+    temp = tempfile.NamedTemporaryFile()
+    td = tempfile.TemporaryDirectory()
+   
+    POSCAR = "../POSCAR_NaCl"
+    
+    for calc in calcs:
+        if calc == "turbomole":
+            name = td.name
+        else:
+            name = temp.name
+        print(f"Testing conversion for {calc}")
+        if calc in require_extra_info:
+            with pytest.raises(RuntimeError):
+                # These calcs need additional info to write their input files
+                convert_crystal_structure(POSCAR, "vasp", name, calc)
+        else:
+            convert_crystal_structure(POSCAR, "vasp", name, calc)

--- a/test/interface/test_conversion.py
+++ b/test/interface/test_conversion.py
@@ -10,6 +10,7 @@ def test_conversion():
     require_extra_info = ["wien2k", "siesta", "cp2k", "crystal", "fleur", "abacus"]
 
     parent_dir = os.path.dirname(os.path.abspath(__file__))
+    parent_dir = os.path.dirname(parent_dir)
     temp = tempfile.NamedTemporaryFile()
     td = tempfile.TemporaryDirectory()
     POSCAR = os.path.join(parent_dir, "POSCAR_NaCl")
@@ -19,7 +20,6 @@ def test_conversion():
             name = td.name
         else:
             name = temp.name
-        print(f"Testing conversion for {calc}")
         if calc in require_extra_info:
             with pytest.raises(RuntimeError):
                 # These calcs need additional info to write their input files

--- a/test/interface/test_conversion.py
+++ b/test/interface/test_conversion.py
@@ -1,19 +1,22 @@
 """Test Conversion between calculator formats"""
 
-import tempfile, pytest
-from phonopy.interface.calculator import convert_crystal_structure, calculator_info
+import tempfile
+
+import pytest
+
+from phonopy.interface.calculator import calculator_info, convert_crystal_structure
 
 
 def test_conversion():
-    """calcs that can use extra info are below"""
+    """Calcs that can use extra info are below"""
     calcs = calculator_info.keys()
     require_extra_info = ["wien2k", "siesta", "cp2k", "crystal", "fleur", "abacus"]
-    
+
     temp = tempfile.NamedTemporaryFile()
     td = tempfile.TemporaryDirectory()
-   
+
     POSCAR = "../POSCAR_NaCl"
-    
+
     for calc in calcs:
         if calc == "turbomole":
             name = td.name


### PR DESCRIPTION
It is currently impossible to pass the additional information necessary to write many types of input files like qe, wien2k, etc with the file conversion script. I added an optional argument that can accept this information, and wrote clearer error messages explaining why the files can't be built if the info is not provided.

In the case of QE, dummy pp file names were already being written if the names were not provided, but I did not add analogous dummy info for the other calculators that require this extra info because I'm not familiar with their formatting.