### PR TITLE
Major refactoring of collect_cell_info.py

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -743,7 +743,7 @@ class Phonopy:
             self._set_dynamical_matrix()
 
     @property
-    def supercells_with_displacements(self) -> Optional[list[PhonopyAtoms]]:
+    def supercells_with_displacements(self) -> list[PhonopyAtoms] | None:
         """Return supercells with displacements.
 
         list of PhonopyAtoms

--- a/phonopy/cui/collect_cell_info.py
+++ b/phonopy/cui/collect_cell_info.py
@@ -53,24 +53,7 @@ from phonopy.structure.atoms import PhonopyAtoms
 
 @dataclass
 class CellInfoResult:
-    """Dataclass to hold the result of collect_cell_info.
-
-    "unitcell": PhonopyAtoms
-        Unit cell.
-    "supercell_matrix": ndarray
-    "primitive_matrix": ndarray
-    "optional_structure_info": list
-        See read_crystal_structure.
-    "interface_mode": str
-        Force calculator or crystal structure format name.
-    "phonopy_yaml": None or instance of the class given by phonopy_yaml_cls
-        Not None when crystal structure was read phonopy.yaml like file.
-    "error_message" : str
-        Unless error exists, this entry should not be in this dict.
-        Otherwise, some error exists. The error message is storedin the
-        string.
-
-    """
+    """Dataclass to hold the result of collect_cell_info."""
 
     unitcell: PhonopyAtoms
     optional_structure_info: tuple

--- a/phonopy/cui/create_force_sets.py
+++ b/phonopy/cui/create_force_sets.py
@@ -51,10 +51,10 @@ from phonopy.structure.dataset import get_displacements_and_forces
 
 
 def create_FORCE_SETS(
-    interface_mode: str,
+    interface_mode: str | None,
     force_filenames: list[str],
-    phpy_yaml: Optional[PhonopyYaml] = None,
-    symmetry_tolerance: Optional[float] = None,
+    phpy_yaml: PhonopyYaml | None = None,
+    symmetry_tolerance: float | None = None,
     wien2k_P1_mode: bool = False,
     force_sets_zero_mode: bool = False,
     disp_filename: str = "disp.yaml",

--- a/phonopy/cui/load.py
+++ b/phonopy/cui/load.py
@@ -321,7 +321,7 @@ def load(
 
     fc = load_helper.select_and_extract_force_constants(
         phonon,
-        fc=_fc,
+        force_constants=_fc,
         force_constants_filename=force_constants_filename,
         is_compact_fc=is_compact_fc,
         log_level=log_level,

--- a/phonopy/cui/load_helper.py
+++ b/phonopy/cui/load_helper.py
@@ -242,7 +242,7 @@ def select_and_load_dataset(
 def select_and_extract_force_constants(
     phonon: Phonopy,
     phonopy_yaml_filename: str | os.PathLike | None = None,
-    fc: NDArray | None = None,  # From phonopy_yaml
+    force_constants: NDArray | None = None,
     force_constants_filename: str | os.PathLike | None = None,
     is_compact_fc: bool = True,
     log_level: int = 0,
@@ -251,14 +251,12 @@ def select_and_extract_force_constants(
 
     1. From fc (ndarray) in phonopy_yaml.
     2. From FORCE_CONSTANTS file or force_constants.hdf5 file.
-    3.
-    4. Maybe already in phonopy.force_constants.
 
     """
     _fc = None
     _force_constants_filename = None
-    if fc is not None:  # 1
-        _fc = fc
+    if force_constants is not None:  # 1
+        _fc = force_constants
         _force_constants_filename = phonopy_yaml_filename
     elif force_constants_filename is not None:  # 2
         _fc = _read_force_constants_file(phonon, force_constants_filename)
@@ -450,7 +448,7 @@ def _prepare_dataset_by_pypolymlp(
     phonon.evaluate_mlp()
 
 
-def _read_force_constants_file(phonon: Phonopy, force_constants_filename):
+def _read_force_constants_file(phonon: Phonopy, force_constants_filename) -> NDArray:
     dot_split = force_constants_filename.split(".")
     p2s_map = phonon.primitive.p2s_map
     if len(dot_split) > 1 and dot_split[-1] == "hdf5":

--- a/phonopy/cui/settings.py
+++ b/phonopy/cui/settings.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from typing import Literal
 
 import numpy as np
 from numpy.typing import NDArray
@@ -109,7 +110,7 @@ class Settings:
         self.num_frequency_points = None
         self.primitive_matrix = None
         self.qpoints = None
-        self.random_displacements: str | int | None = None
+        self.random_displacements: Literal["auto"] | int | None = None
         self.random_seed = None
         self.rd_number_estimation_factor = None
         self.read_qpoints = False

--- a/phonopy/cui/show_symmetry.py
+++ b/phonopy/cui/show_symmetry.py
@@ -38,6 +38,7 @@ import numpy as np
 import spglib
 
 from phonopy import Phonopy
+from phonopy.cui.collect_cell_info import CellInfoResult
 from phonopy.interface.calculator import (
     get_default_cell_filename,
     write_crystal_structure,
@@ -49,7 +50,7 @@ from phonopy.structure.cells import determinant, guess_primitive_matrix
 from phonopy.structure.symmetry import Symmetry
 
 
-def check_symmetry(phonon: Phonopy, cell_info: dict):
+def check_symmetry(phonon: Phonopy, cell_info: CellInfoResult):
     """Check symmetry of input cell.
 
     This function first standardizes the input crystal structure based on
@@ -62,7 +63,7 @@ def check_symmetry(phonon: Phonopy, cell_info: dict):
     """
     base_fname = get_default_cell_filename(phonon.calculator)
     symprec = phonon.primitive_symmetry.tolerance
-    (bravais_lattice, bravais_pos, bravais_numbers) = spglib.refine_cell(
+    (bravais_lattice, bravais_pos, bravais_numbers) = spglib.refine_cell(  # type: ignore
         phonon.primitive.totuple(), symprec
     )
     _, _, _, perm = sort_positions_by_symbols(bravais_numbers)
@@ -74,19 +75,21 @@ def check_symmetry(phonon: Phonopy, cell_info: dict):
     trans_mat = guess_primitive_matrix(bravais, symprec=symprec)
     ph = Phonopy(
         bravais,
-        supercell_matrix=cell_info["supercell_matrix"],
+        supercell_matrix=cell_info.supercell_matrix,
         primitive_matrix=trans_mat,
         calculator=phonon.calculator,
     )
 
     if (
-        cell_info["phonopy_yaml"] is None
-        or cell_info["phonopy_yaml"].supercell_matrix is None
-    ) and determinant(cell_info["supercell_matrix"]) > 1:
-        print(f'Input crystal structure: "{cell_info["optional_structure_info"][0]}"')
-        phyml = PhonopyYaml().set_phonon_info(ph)
-        phyml.frequency_unit_conversion_factor = None
-        phyml.symmetry = None
+        cell_info.phonopy_yaml is None
+        or cell_info.phonopy_yaml.supercell_matrix is None
+    ) and determinant(cell_info.supercell_matrix) > 1:
+        print(f'Input crystal structure: "{cell_info.optional_structure_info[0]}"')
+        phyml = PhonopyYaml()
+        phyml.supercell = ph.supercell
+        phyml.supercell_matrix = ph.supercell_matrix
+        phyml.primitive = ph.primitive
+        phyml.primitive_matrix = ph.primitive_matrix
         with open("phonopy_supercell.yaml", "w") as w:
             print(phyml, file=w)
 
@@ -104,13 +107,15 @@ def check_symmetry(phonon: Phonopy, cell_info: dict):
         _show_symmetry_yaml(phonon, cell_info, base_fname, ph)
 
 
-def _show_symmetry_yaml(phonon: Phonopy, cell_info: dict, base_fname: str, ph: Phonopy):
+def _show_symmetry_yaml(
+    phonon: Phonopy, cell_info: CellInfoResult, base_fname: str, ph: Phonopy
+):
     print(
         _get_symmetry_yaml(phonon.primitive, phonon.primitive_symmetry, phonon.version)
     )
-    print(f"# Input crystal structure: \"{cell_info['optional_structure_info'][0]}'")
-    if cell_info["phonopy_yaml"] is None:
-        optional_structure_info = cell_info["optional_structure_info"]
+    print(f'# Input crystal structure: "{cell_info.optional_structure_info[0]}"')
+    if cell_info.phonopy_yaml is None:
+        optional_structure_info = cell_info.optional_structure_info
         filename = "B" + base_fname
         print(f'# Symmetrized conventional unit cell is written into "{filename}" and')
         write_crystal_structure(

--- a/phonopy/exception.py
+++ b/phonopy/exception.py
@@ -45,3 +45,9 @@ class ForceCalculatorRequiredError(RuntimeError):
     """Exception when force calculator is required to compute force constants."""
 
     pass
+
+
+class CellNotFoundError(RuntimeError):
+    """Exception when unit cell not found."""
+
+    pass

--- a/phonopy/file_IO.py
+++ b/phonopy/file_IO.py
@@ -40,10 +40,11 @@ import io
 import pathlib
 import sys
 from collections.abc import Sequence
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import yaml
+from numpy.typing import NDArray
 
 try:
     from yaml import CLoader as Loader
@@ -351,11 +352,11 @@ def get_FORCE_CONSTANTS_lines(force_constants, p2s_map=None):
 
 
 def write_force_constants_to_hdf5(
-    force_constants: np.ndarray,
+    force_constants: NDArray,
     filename: str = "force_constants.hdf5",
-    p2s_map: Optional[np.ndarray] = None,
-    physical_unit: Optional[str] = None,
-    compression: Optional[Union[str, int]] = None,
+    p2s_map: NDArray | None = None,
+    physical_unit: str | None = None,
+    compression: str | int | None = None,
 ):
     """Write force constants in hdf5 format.
 

--- a/phonopy/harmonic/force_constants.py
+++ b/phonopy/harmonic/force_constants.py
@@ -37,9 +37,9 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Optional, Union
 
 import numpy as np
+from numpy.typing import NDArray
 
 from phonopy.structure.atoms import PhonopyAtoms
 from phonopy.structure.cells import (
@@ -62,7 +62,7 @@ class FDFCSolver:
     def __init__(
         self,
         supercell: PhonopyAtoms,
-        primitive: Optional[Primitive],
+        primitive: Primitive | None,
         symmetry: Symmetry,
         dataset: dict,
         is_compact_fc: bool = False,
@@ -94,8 +94,8 @@ class FDFCSolver:
         supercell: PhonopyAtoms,
         symmetry: Symmetry,
         dataset,
-        atom_list: Optional[Union[Sequence[int], np.ndarray]] = None,
-        primitive: Optional[Primitive] = None,
+        atom_list: Sequence[int] | NDArray | None = None,
+        primitive: Primitive | None = None,
     ) -> np.ndarray:
         """Force constants are computed.
 
@@ -160,7 +160,7 @@ class FDFCSolver:
 
 def compact_fc_to_full_fc(
     primitive: Primitive, compact_fc: np.ndarray, log_level: int = 0
-):
+) -> NDArray:
     """Transform compact fc to full fc."""
     fc = np.zeros(
         (compact_fc.shape[1], compact_fc.shape[1], 3, 3), dtype="double", order="C"
@@ -175,7 +175,7 @@ def compact_fc_to_full_fc(
 
 def full_fc_to_compact_fc(
     primitive: Primitive, full_fc: np.ndarray, log_level: int = 0
-):
+) -> NDArray:
     """Transform full fc to compact fc."""
     p2s_map = primitive.p2s_map
     fc = np.zeros((len(p2s_map), full_fc.shape[1], 3, 3), dtype="double", order="C")
@@ -207,7 +207,8 @@ def rearrange_force_constants_array(
 
     """
     assert full_fc.shape[0] == full_fc.shape[1]
-    indices: list = isclose(a, b, with_arbitrary_order=True, return_order=True)
+    indices = isclose(a, b, with_arbitrary_order=True, return_order=True)
+    assert not isinstance(indices, bool)
     re_fc = np.zeros_like(full_fc)
     for i, j in enumerate(indices):
         re_fc[i] = full_fc[j][indices]
@@ -581,7 +582,10 @@ def set_permutation_symmetry(force_constants):
 
 
 def show_drift_force_constants(
-    force_constants, primitive=None, name="force constants", values_only=False
+    force_constants,
+    primitive: Primitive | None = None,
+    name="force constants",
+    values_only=False,
 ):
     """Show force constants drift."""
     if force_constants.shape[0] == force_constants.shape[1]:
@@ -600,6 +604,7 @@ def show_drift_force_constants(
                 maxval2 = val2
                 jk2 = [j, k]
     else:
+        assert primitive is not None
         s2p_map = primitive.s2p_map
         p2s_map = primitive.p2s_map
         p2p_map = primitive.p2p_map

--- a/phonopy/interface/calculator.py
+++ b/phonopy/interface/calculator.py
@@ -35,15 +35,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from __future__ import annotations
 
+import os
 import pathlib
 import warnings
 from argparse import ArgumentParser
 from collections.abc import Sequence
 from math import pi, sqrt
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import yaml
+from numpy.typing import NDArray
 
 from phonopy.file_IO import get_supported_file_extensions_for_compression
 from phonopy.interface.phonopy_yaml import PhonopyYaml
@@ -125,10 +127,10 @@ def convert_crystal_structure(
 
 
 def write_crystal_structure(
-    filename: Optional[str],
+    filename: str | os.PathLike | None,
     cell: PhonopyAtoms,
-    interface_mode: Optional[str] = None,
-    optional_structure_info: Optional[tuple] = None,
+    interface_mode: str | None = None,
+    optional_structure_info: tuple | None = None,
 ):
     """Write crystal structure to file in each calculator format.
 
@@ -270,10 +272,10 @@ def write_supercells_with_displacements(
     interface_mode: str,
     supercell: PhonopyAtoms,
     cells_with_disps: Sequence[PhonopyAtoms],
-    optional_structure_info: Optional[tuple] = None,
-    displacement_ids: Optional[Union[Sequence, np.ndarray]] = None,
+    optional_structure_info: tuple,
+    displacement_ids: Sequence | NDArray | None = None,
     zfill_width: int = 3,
-    additional_info: Optional[dict] = None,
+    additional_info: dict | None = None,
 ):
     """Write supercell with displacements to files in each calculator format.
 
@@ -434,8 +436,8 @@ def read_crystal_structure(
     filename=None,
     interface_mode=None,
     chemical_symbols=None,
-    phonopy_yaml_cls: Optional[type[PhonopyYaml]] = None,
-):
+    phonopy_yaml_cls: type[PhonopyYaml] | None = None,
+) -> tuple[PhonopyAtoms, tuple]:
     """Return crystal structure from file in each calculator format.
 
     Parameters
@@ -990,7 +992,7 @@ def get_force_constant_conversion_factor(unit, interface_mode):
 
 
 def _read_phonopy_yaml(
-    filename: str, phonopy_yaml_cls: Optional[type[PhonopyYaml]]
+    filename: str, phonopy_yaml_cls: type[PhonopyYaml] | None
 ) -> tuple[PhonopyAtoms, tuple]:
     cell_filename = _get_cell_filename(filename, phonopy_yaml_cls)
     if cell_filename is None:
@@ -1012,7 +1014,7 @@ def _read_phonopy_yaml(
 
 
 def _get_cell_filename(
-    filename, phonopy_yaml_cls: Optional[type[PhonopyYaml]]
+    filename, phonopy_yaml_cls: type[PhonopyYaml] | None
 ) -> Optional[str]:
     cell_filename = None
 

--- a/phonopy/phonon/modulation.py
+++ b/phonopy/phonon/modulation.py
@@ -34,6 +34,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 from typing import Union
 
 import numpy as np

--- a/phonopy/phonon/random_displacements.py
+++ b/phonopy/phonon/random_displacements.py
@@ -40,6 +40,7 @@ from collections.abc import Sequence
 from typing import Optional, Union
 
 import numpy as np
+from numpy.typing import NDArray
 
 from phonopy.harmonic.dynamical_matrix import get_dynamical_matrix
 from phonopy.harmonic.dynmat_to_fc import (
@@ -364,8 +365,11 @@ class RandomDisplacements:
         return self._comm_points[self._ii + self._ij] / float(N)
 
     @property
-    def integrated_modes(self):
+    def integrated_modes(self) -> NDArray:
         """Return commensurate q-points where phonons are computed.."""
+        if self._conditions_ii is None:
+            raise RuntimeError("Run random displacements first.")
+
         if self._conditions_ij is None:
             return self._conditions_ii
         else:

--- a/phonopy/sscha/core.py
+++ b/phonopy/sscha/core.py
@@ -37,7 +37,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Optional
+from typing import Literal
 
 import numpy as np
 
@@ -53,11 +53,11 @@ class MLPSSCHA:
         self,
         ph: Phonopy,
         mlp: PhonopyMLP,
-        temperature: Optional[float] = None,
-        number_of_snapshots: Optional[int] = None,
-        max_iterations: Optional[int] = None,
-        distance: Optional[float] = None,
-        fc_calculator: Optional[str] = None,
+        temperature: float | None = None,
+        number_of_snapshots: int | Literal["auto"] | None = None,
+        max_iterations: int | None = None,
+        distance: float | None = None,
+        fc_calculator: str | None = None,
         log_level: int = 0,
     ):
         """Init method.

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -35,7 +35,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 from typing import Optional, Union
 
@@ -101,14 +100,14 @@ class Supercell(PhonopyAtoms):
 
         """
         self._is_old_style = is_old_style
-        self._s2u_map = None
-        self._u2s_map = None
-        self._u2u_map = None
-        self._supercell_matrix = np.array(supercell_matrix, dtype="intc")
+        self._s2u_map: NDArray
+        self._u2s_map: NDArray
+        self._u2u_map: dict[int, int]
+        self._supercell_matrix = np.array(supercell_matrix, dtype="intc", order="C")
         self._create_supercell(unitcell, symprec)
 
     @property
-    def supercell_matrix(self):
+    def supercell_matrix(self) -> NDArray:
         """Return supercell_matrix.
 
         Returns
@@ -120,18 +119,8 @@ class Supercell(PhonopyAtoms):
         """
         return self._supercell_matrix
 
-    def get_supercell_matrix(self):
-        """Return supercell_matrix."""
-        warnings.warn(
-            "Supercell.get_supercell_matrix() is deprecated."
-            "Use Supercell.supercell_matrix attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.supercell_matrix
-
     @property
-    def s2u_map(self):
+    def s2u_map(self) -> NDArray:
         """Return atomic index mapping table from supercell to unit cell.
 
         Each array index and the stored value correspond to the supercell atom
@@ -145,18 +134,8 @@ class Supercell(PhonopyAtoms):
         """
         return self._s2u_map
 
-    def get_supercell_to_unitcell_map(self):
-        """Return atomic index mapping table from supercell to unit cell."""
-        warnings.warn(
-            "Supercell.get_supercell_to_unitcell_map() is deprecated."
-            "Use Supercell.s2u_map attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.s2u_map
-
     @property
-    def u2s_map(self):
+    def u2s_map(self) -> NDArray:
         """Return atomic index mapping table from unit cell to supercell.
 
         Each array index and the stored value correspond to the unit cell atom
@@ -170,18 +149,8 @@ class Supercell(PhonopyAtoms):
         """
         return self._u2s_map
 
-    def get_unitcell_to_supercell_map(self):
-        """Return atomic index mapping table from unit cell to supercell."""
-        warnings.warn(
-            "Supercell.get_unitcell_to_supercell_map() is deprecated."
-            "Use Supercell.u2s_map attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.u2s_map
-
     @property
-    def u2u_map(self):
+    def u2u_map(self) -> dict[int, int]:
         """Return atomic index mapping table from unit cell to unit cell.
 
         Returns
@@ -192,16 +161,6 @@ class Supercell(PhonopyAtoms):
 
         """
         return self._u2u_map
-
-    def get_unitcell_to_unitcell_map(self):
-        """Return atomic index mapping table from unit cell to unit cell."""
-        warnings.warn(
-            "Supercell.get_unitcell_to_unitcell_map() is deprecated."
-            "Use Supercell.u2s_map attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.u2u_map
 
     def _create_supercell(self, unitcell: PhonopyAtoms, symprec):
         mat = self._supercell_matrix
@@ -236,12 +195,15 @@ class Supercell(PhonopyAtoms):
         N = num_satom // num_uatom
 
         if N != determinant(self._supercell_matrix):
-            print("Supercell creation failed.")
-            print(
-                "Probably some atoms are overwrapped. The mapping table is given below."
+            msg = "\n".join(
+                [
+                    "Supercell creation failed.",
+                    "Probably some atoms are overwrapped. "
+                    "The mapping table is given below.",
+                    str(mapping_table),
+                ]
             )
-            print(mapping_table)
-            super().__init__()
+            raise RuntimeError(msg)
         else:
             super().__init__(
                 symbols=supercell.symbols,
@@ -376,16 +338,16 @@ class Primitive(PhonopyAtoms):
         self._primitive_matrix = np.array(primitive_matrix, dtype="double", order="C")
         self._symprec = symprec
         self._store_dense_svecs = store_dense_svecs
-        self._p2s_map: np.ndarray
-        self._s2p_map: np.ndarray
+        self._p2s_map: NDArray
+        self._s2p_map: NDArray
         self._p2p_map: dict[int, int]
-        self._smallest_vectors: np.ndarray
-        self._multiplicity: np.ndarray
-        self._atomic_permutations: np.ndarray
+        self._smallest_vectors: NDArray
+        self._multiplicity: NDArray
+        self._atomic_permutations: NDArray
         self._run(supercell, positions_to_reorder=positions_to_reorder)
 
     @property
-    def primitive_matrix(self) -> np.ndarray:
+    def primitive_matrix(self) -> NDArray:
         """Return primitive_matrix.
 
         Returns
@@ -398,18 +360,8 @@ class Primitive(PhonopyAtoms):
         """
         return self._primitive_matrix
 
-    def get_primitive_matrix(self):
-        """Return primitive_matrix."""
-        warnings.warn(
-            "Primitive.get_primitive_matrix() is deprecated."
-            "Use Primitive.primitive_matrix attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.primitive_matrix
-
     @property
-    def p2s_map(self) -> np.ndarray:
+    def p2s_map(self) -> NDArray:
         """Return mapping table of atoms from primitive cell to supercell.
 
         Returns
@@ -422,18 +374,8 @@ class Primitive(PhonopyAtoms):
         """
         return self._p2s_map
 
-    def get_primitive_to_supercell_map(self):
-        """Return mapping table of atoms from primitive cell to supercell."""
-        warnings.warn(
-            "Primitive.get_primitive_to_supercell_map() is deprecated."
-            "Use Primitive.p2s_map attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.p2s_map
-
     @property
-    def s2p_map(self) -> np.ndarray:
+    def s2p_map(self) -> NDArray:
         """Return mapping table of atoms from supercell to primitive cells.
 
         Returns
@@ -445,16 +387,6 @@ class Primitive(PhonopyAtoms):
 
         """
         return self._s2p_map
-
-    def get_supercell_to_primitive_map(self):
-        """Return mapping table of atoms from supercell to primitive cells."""
-        warnings.warn(
-            "Primitive.get_supercell_to_primitive_map() is deprecated."
-            "Use Primitive.s2p_map attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.s2p_map
 
     @property
     def p2p_map(self) -> dict[int, int]:
@@ -470,17 +402,7 @@ class Primitive(PhonopyAtoms):
         """
         return self._p2p_map
 
-    def get_primitive_to_primitive_map(self):
-        """Return mapping table of indices in supercell and primitive cell."""
-        warnings.warn(
-            "Primitive.get_primitive_to_primitive_map() is deprecated."
-            "Use Primitive.p2p_map attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.p2p_map
-
-    def get_smallest_vectors(self) -> tuple[np.ndarray, np.ndarray]:
+    def get_smallest_vectors(self) -> tuple[NDArray, NDArray]:
         """Return shortest vectors and multiplicities.
 
         See also the docstring of `ShortestPairs`. The older less densen format
@@ -509,7 +431,7 @@ class Primitive(PhonopyAtoms):
         return self._smallest_vectors, self._multiplicity
 
     @property
-    def atomic_permutations(self) -> np.ndarray:
+    def atomic_permutations(self) -> NDArray:
         """Return atomic index permutations by pure translations.
 
         Returns
@@ -527,16 +449,6 @@ class Primitive(PhonopyAtoms):
 
         """
         return self._atomic_permutations
-
-    def get_atomic_permutations(self):
-        """Return atomic index permutations by pure translations."""
-        warnings.warn(
-            "Primitive.get_atomic_permutations() is deprecated."
-            "Use Primitive.atomic_permutations attribute.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.atomic_permutations
 
     @property
     def store_dense_svecs(self) -> bool:
@@ -940,7 +852,7 @@ def isclose(
     atol: float = 1e-8,
     with_arbitrary_order: bool = False,
     return_order: bool = False,
-) -> Union[bool, list]:
+) -> bool | list:
     """Check equivalence of two cells.
 
     Cell-b is compared with respect to cell-a.
@@ -1395,7 +1307,7 @@ def compute_all_sg_permutations(
     translations,  # scaled
     lattice,  # column vectors
     symprec,
-):
+) -> NDArray:
     """Compute permutations for space group operations.
 
     See 'compute_permutation_for_rotation' for more info.

--- a/phonopy/structure/symmetry.py
+++ b/phonopy/structure/symmetry.py
@@ -89,12 +89,12 @@ class Symmetry:
         self._international_table = None
         self._dataset = None
         self._wyckoff_letters = None
-        self._map_atoms = None
-        self._atomic_permutations = None
+        self._map_atoms: NDArray
+        self._atomic_permutations: NDArray
         self._pointgroup_operations: NDArray
         self._reciprocal_operations: NDArray
         self._pointgroup = None
-        self._independent_atoms = None
+        self._independent_atoms: NDArray
         self._map_operations = None
 
         magmom = cell.magnetic_moments
@@ -205,11 +205,11 @@ class Symmetry:
         )
         return self.dataset
 
-    def get_independent_atoms(self):
+    def get_independent_atoms(self) -> NDArray:
         """Return symmetrically unique atoms."""
         return self._independent_atoms
 
-    def get_map_atoms(self):
+    def get_map_atoms(self) -> NDArray:
         """Return equivalent_atoms of spglib dataset.
 
         Returns
@@ -285,7 +285,7 @@ class Symmetry:
         return self.reciprocal_operations
 
     @property
-    def atomic_permutations(self):
+    def atomic_permutations(self) -> NDArray:
         """Return atomic index permutations by space group operations.
 
         shape=(operations, positions)


### PR DESCRIPTION
Changed to that `collect_cell_info` function returns `CellInfoResult` dataclass instance otherwise emit `CellNotFoundError`. 
In `CellInfoResult`, `unitcell` (`PhonopyAtoms`) and `optional_structure_info` (`tuple`) are always returned.