### PR TITLE
add reciprocal_lattice and mass to qpoints.hdf5

### DIFF
--- a/phonopy/phonon/qpoints.py
+++ b/phonopy/phonon/qpoints.py
@@ -170,7 +170,7 @@ class QpointsPhonon:
 
         with h5py.File(filename, "w") as w:
             w.create_dataset("reciprocal_lattice", data=np.linalg.inv(self._lattice.T))
-            w.create_dataset("mass", data=self._masses)
+            w.create_dataset("masses", data=self._masses)
             w.create_dataset("qpoint", data=self._qpoints)
             w.create_dataset("frequency", data=self._frequencies)
             if self._with_eigenvectors:


### PR DESCRIPTION
Would be very useful to have the masses and reciprocal lattice in the new qpoints.hdf5 file. This small change is adding them.