### PR TITLE
qlm interface: refactor and preserve input context

### DIFF
--- a/doc/qlm.md
+++ b/doc/qlm.md
@@ -5,32 +5,17 @@
 This is a tutorial for the interface between phonopy and Questaal
 [https://www.questaal.org/](https://www.questaal.org/).
 
-## Supported LM tokens
-
-```
-    XPOS, ATOM, ALAT, PLAT
-```
-
-The interface uses LM suite site files. Such files have only a small amount of
-information within them relating to the calculation. At present, the interface
-requires the use of fractional co-ordinates. Since phonopy is capable of
-handling cartesian co-ordinates such an extension will be realised soon.
-
+The interface uses the site files. Such files have only a small amount of
+information within them relating to the calculation. Extention to support
+ctrl files is planned.
 
 ## How to run
 
 The following is a walkthrough for a phonopy calculation with LM:
 
-1.  Create a site file with the LM suite supercell maker, `lmscell`. For
-    instance, use this command,
-
-    ```bash
-        echo 'm 1 0 0 0 1 0 0 0 1' | lmscell --wsitex ctrl.lm
-    ```
-
-    This will write `site.lm` to disk in the current directory. Note that this
-    site file will be written in fractional co-ordinates. At present, the LM
-    interface supports only fractional co-ordinates.
+1.  Setup an `lmf` calculation with external site file instead of a `site`
+    section in the ctrl file. Both relative and cartesian coordinates are
+    supported. Remember to set `forces=1` in section `ham` of the ctrl file.
 
 2.  Read the LM site file and create supercells with a command of the form,
 
@@ -41,9 +26,9 @@ The following is a walkthrough for a phonopy calculation with LM:
     In this example, 2x2x2 supercells are created. `supercell.lm` and
     `supercell-{id}.lm` correspond to the perfect supercell and supercells
     with displacements, respectively. These supercell files are LM site files
-    ready to be used in `ctrl.lm`. A file named `phonopy_disp.yaml` is also
-    created in the current directory. This file contains information pertaining
-    to displacements.
+    ready to be used in `ctrl.lm`. The original `alat` present in site.lm is
+    preserved. A file named `phonopy_disp.yaml` is also created in the current
+    directory. This file contains information pertaining to displacements.
 
 3.  Next, run the calculations for the generated displacements and be sure to
     use the `--wforce=force` flag. This will write a file containing forces.

--- a/phonopy/interface/calculator.py
+++ b/phonopy/interface/calculator.py
@@ -255,10 +255,9 @@ def write_crystal_structure(
         lammps.write_lammps(filename, cell)
 
     elif interface_mode == "qlm":
-        import phonopy.interface.qlm as qlm
+        import phonopy.interface.qlm as write_qlm
 
-        qlm.write_qlm(filename, cell)
-
+        write_qlm(filename, cell)
     elif interface_mode == "pwmat":
         import phonopy.interface.pwmat as pwmat
 
@@ -407,8 +406,8 @@ def write_supercells_with_displacements(
     elif interface_mode == "qlm":
         import phonopy.interface.qlm as qlm
 
-        qlm.write_supercells_with_displacements(*args, **kwargs)
-
+        qlm_args = args + optional_structure_info
+        qlm.write_supercells_with_displacements(*qlm_args, **kwargs)
     else:
         raise RuntimeError("No calculator interface was found.")
 
@@ -564,8 +563,8 @@ def read_crystal_structure(
     elif interface_mode == "qlm":
         from phonopy.interface.qlm import read_qlm
 
-        unitcell = read_qlm(cell_filename)
-        return unitcell, (cell_filename,)
+        struct_info = read_qlm(cell_filename)
+        return struct_info
 
     else:
         raise RuntimeError("No calculator interface was found.")

--- a/phonopy/interface/qlm.py
+++ b/phonopy/interface/qlm.py
@@ -1,16 +1,13 @@
 """Questaal/LMTO calculator interface."""
 
-# Initial version by GCGS, adaptation to phonopy v2 by DLP
+# Initial version by GCGS, adaptation to phonopy v2 and subsequent revision by DLP
 
+import os
 import sys
 
 import numpy as np
 
-from phonopy.interface.vasp import (
-    check_forces,
-    get_drift_forces,
-    sort_positions_by_symbols,
-)
+from phonopy.interface.vasp import check_forces, get_drift_forces
 from phonopy.structure.atoms import PhonopyAtoms, symbol_map
 
 
@@ -39,129 +36,188 @@ def parse_set_of_forces(num_atoms, forces_filenames, verbose=True):
 
 def read_qlm(filename):
     """Read crystal structure."""
-    with open(filename, "r") as f:
-        lines = f.readlines()
+    qlm_ctx = QlmFl()
+    qlm_ctx.load_site(filename)
 
-    header = lines[0]
-    sites = lines[2:]
+    plat = qlm_ctx.plat
+    poss = qlm_ctx.positions
 
-    qlm_in = QlmIn(header, sites)
-    tags = qlm_in.get_variables(header, sites)
+    scaled_poss = poss
+    if not qlm_ctx.xpos:
+        scaled_poss = poss @ np.linalg.inv(plat)
 
-    plat = [tags["alat"] * np.array(tags["plat"][i]) for i in range(3)]
-    positions = tags["atoms"]["positions"]
-    symbols = tags["atoms"]["spfnames"]
+    plat *= qlm_ctx.alat
 
-    numbers = []
-    for s in symbols:
-        numbers.append(symbol_map[s])
+    cell = PhonopyAtoms(
+        cell=plat, scaled_positions=scaled_poss, symbols=qlm_ctx.symbols_sfxn
+    )
 
-    cell = PhonopyAtoms(numbers=numbers, cell=plat, scaled_positions=positions)
-
-    return cell
+    return cell, (qlm_ctx,)
 
 
-def write_qlm(filename, cell):
-    """Write cell to file."""
-    with open(filename, "w") as f:
-        f.write(get_qlm_structure(cell))
+def to_site_str(cell, *extra_args):
+    """Convert cell to site-formatted string."""
+    qctx = extra_args[0] if extra_args else QlmFl()
+    return qctx.to_site_str(cell)
+
+
+def write_qlm(filename, cell, *extra_args):
+    """Write site file."""
+    qctx = extra_args[0] if extra_args else QlmFl()
+    qctx.write_site(cell, filename=filename)
 
 
 def write_supercells_with_displacements(
-    supercell,
-    cells_with_displacements,
-    ids,
-    pre_filename="supercell",
-    width=3,
-    ext="lm",
+    supercell, cells_with_displacements, ids, qlm_ctx, width=3
 ):
     """Write supercells with displacements to files."""
-    write_qlm(
-        "{pre_filename}.{ext}".format(pre_filename=pre_filename, ext=ext), supercell
-    )
+    qlm_ctx.write_site(supercell, prefix="supercell")
     for i, cell in zip(ids, cells_with_displacements):
-        write_qlm(
-            "{pre_filename}-{0:0{width}}.{ext}".format(
-                i, pre_filename=pre_filename, width=width, ext=ext
-            ),
-            cell,
+        qlm_ctx.write_site(cell, prefix="supercell", idx=i, width=width)
+
+
+class QlmFl:
+    """Class to read and write QLM site files."""
+
+    def __init__(self):
+        self._filename = "site.lm"
+        self._ext = ".lm"
+        self._content = ""
+
+        self.natom = 0
+        self.xpos = False
+        self.alat = 1.0
+        self.plat = np.eye(3)
+
+        self.symbols = []
+        self.symbols_sfxn = []
+        self.positions = np.array([])
+
+        self._lsorted_els = sorted(symbol_map.keys(), key=len, reverse=True)
+
+        self._sq2sp = dict()
+        self._sp2sq = dict()
+
+    def split_symbol_element(self, s):
+        """Split symbol to element and suffix."""
+        el_sfx = "", s
+
+        for e in self._lsorted_els:
+            if s.startswith(e):
+                el_sfx = e, s[len(e) :]
+                break
+
+        return el_sfx
+
+    def load_site(self, filename):
+        """Fill internal variables from site file."""
+        self._filename = filename
+        self._ext = os.path.splitext(filename)[1]
+        self._content = open(filename, "r").read()
+
+        lines = self._content.splitlines()
+        header = lines[0]
+        sites = lines[2:]
+
+        hlist = header.replace("=", "= ").split()
+
+        self.xpos = "xpos" in hlist
+
+        idx = hlist.index("nbas=")
+        self.natom = int(hlist[idx + 1])
+
+        idx = hlist.index("alat=")
+        self.alat = float(hlist[idx + 1])
+
+        idx = hlist.index("plat=")
+        self.plat = np.array(hlist[idx + 1 : idx + 10], dtype=float)
+        self.plat.shape = 3, 3
+
+        nl = 0
+        positions = []
+        for site in sites:
+            if site.strip() != "":
+                ls = site.split()
+                self.symbols.append(ls[0])
+                positions.append(ls[1:4])
+                nl += 1
+                if nl == self.natom:
+                    break
+
+        self.positions = np.array(positions, dtype=float)
+
+        sfx = {self.split_symbol_element(symb)[1] for symb in self.symbols}
+        sfx = {s for s in sfx if s != ""}
+        sfxn = {s for s in sfx if s.isnumeric()}  # preserve numeric suffixes mapping
+        mxn = max(map(int, sfxn)) if len(sfxn) != 0 else 0
+        sfx = {s for s in sfx if not s.isnumeric()}
+        qls2fns = dict(((s, str(n + mxn + 1)) for n, s in enumerate(sfx)))
+        qls2fns |= dict((s, s) for s in sfxn)
+        qls2fns[""] = ""
+
+        self._sq2sp = dict()
+        for symb in self.symbols:
+            e, s = self.split_symbol_element(symb)
+            fnsymb = e + qls2fns[s]
+            if symb not in self._sq2sp:
+                self._sq2sp[symb] = fnsymb
+
+        self._sp2sq = dict((v, k) for k, v in self._sq2sp.items())
+
+        self.symbols_sfxn = list(self._sq2sp[symb] for symb in self.symbols)
+
+        assert self.natom == self.positions.shape[0]
+        assert self.natom == len(self.symbols)
+
+    def to_site_str(self, cell):
+        """Write cell to site file formatted string."""
+        lattice = cell.cell / self.alat
+        natoms = len(cell.symbols)
+        plat_str = " ".join(
+            [("%.12f" % p).lstrip().rstrip("0").rstrip(".") for p in lattice.ravel()]
         )
 
+        lines = [
+            "% site-data vn=3.0"
+            + (" xpos" if self.xpos else "")
+            + " fast io=15"
+            + " nbas=%d" % natoms
+            + " alat="
+            + ("%.12f" % self.alat).lstrip().rstrip("0").rstrip(".")
+            + " plat="
+            + plat_str
+        ]
+        lines.append("#                              pos")
 
-def get_qlm_structure(cell):
-    """Write cell to string."""
-    lattice = cell.cell
-    (num_atoms, symbols, scaled_positions, sort_list) = sort_positions_by_symbols(
-        cell.symbols, cell.scaled_positions
-    )
+        poss = cell.scaled_positions
+        if not self.xpos:
+            poss = cell.scaled_positions @ lattice
 
-    lines = "%% site-data vn=3.0 xpos fast io=62 nbas=%d" % sum(num_atoms)
-    lines += " alat=1.0 plat=" + ("%.6f " * 9 + "\n") % tuple(lattice.ravel())
-    lines += "#                        pos                                   "
-    lines += "vel                                    eula                     "
-    lines += "vshft  PL rlx\n"
-
-    atom_species = []
-    for i, j in zip(symbols, num_atoms):
-        atom_species.append([i] * j)
-
-    for x, y in zip(sum(atom_species, []), scaled_positions):
-        lines += " %3s" % x
-        lines += (" %12.7f" * 3) % tuple(y)
-        lines += (" %12.7f" * 7) % tuple([0.0] * 7)
-        lines += " 0 111\n"
-
-    return lines
-
-
-class QlmIn:
-    """Class to read QLM structure file."""
-
-    def __init__(self, header, sites):
-        self._set_methods = {
-            "atoms": self._set_atoms,
-            "plat": self._set_plat,
-            "alat": self._set_alat,
-        }
-        self._tags = {"atoms": None, "plat": None, "alat": 1.0}
-
-    def _set_atoms(self, sites):
-        spfnames = []
-        positions = []
-        for i in sites:
-            spfnames.append(i.split()[0])
-            positions.append([float(x) for x in i.split()[1:4]])
-        self._tags["atoms"] = {"spfnames": spfnames, "positions": positions}
-
-    def _set_plat(self, header):
-        plat = []
-        hlist = header.replace("=", "= ").split()
-        index = hlist.index("plat=")
-        for j in range(1, 10, 3):
-            plat.append([float(x) for x in hlist[index + j : index + j + 3]])
-        self._tags["plat"] = plat
-
-    def _set_alat(self, header):
-        hlist = header.split()
-        for j in hlist:
-            if j.startswith("alat"):
-                alat = float(j.split("=")[1])
-                break
-        self._tags["alat"] = alat
-
-    def _check_ord(self, header):
-        if "xpos" not in header.split():
-            raise RuntimeError(
-                "Only site files with fractional coordinates are supported for now."
+        symbs = cell.symbols
+        if len(self._sp2sq) > 0:
+            symbs = list(self._sp2sq[symb] for symb in cell.symbols)
+        for symb, crd in zip(symbs, poss):
+            lines.append(
+                " %7s %17.12f %17.12f %17.12f" % (symb.ljust(7), crd[0], crd[1], crd[2])
             )
 
-    def get_variables(self, header, sites):
-        """Obtain input variables in a dictionary."""
-        self._check_ord(header)
-        self._set_atoms(sites)
-        self._set_plat(header)
-        self._set_alat(header)
-        return self._tags
+        return "\n".join(lines) + "\n"
+
+    def write_site(self, cell, filename="", prefix="", idx=None, width=None):
+        """Write optionally indexed cell to site file."""
+        fname = filename
+
+        if fname == "":
+            fname = self._filename
+
+        if prefix != "":
+            ext = self._ext
+            fname = f"{prefix}{ext}"
+            if idx is not None:
+                fname = f"{prefix}-{idx:0{width}}{ext}"
+
+        with open(fname, "w") as f:
+            f.write(self.to_site_str(cell))
 
 
 if __name__ == "__main__":
@@ -169,7 +225,11 @@ if __name__ == "__main__":
 
     from phonopy.structure.symmetry import Symmetry
 
-    cell = read_qlm(sys.argv[1])
+    cell, (qlm_ctx,) = read_qlm(sys.argv[1])
     symmetry = Symmetry(cell)
+
     print("# %s" % symmetry.get_international_table())
-    print(get_qlm_structure(cell))
+    print(qlm_ctx.to_site_str(cell))
+
+    print(to_site_str(cell))
+    print(to_site_str(cell, qlm_ctx))

--- a/test/interface/test_qlm.py
+++ b/test/interface/test_qlm.py
@@ -6,7 +6,6 @@ import tempfile
 import numpy as np
 
 from phonopy.interface.qlm import (
-    get_qlm_structure,
     parse_set_of_forces,
     read_qlm,
 )
@@ -53,12 +52,12 @@ def test_cell2struct_and_read_qlm():
 #                            pos
  Na        0.0000000000   0.0000000000   0.0000000000
  Na        0.0000000000   0.5000000000   0.5000000000
- Na        0.5000000000   0.0000000000   0.5000000000
- Na        0.5000000000   0.5000000000   0.0000000000
+ Na2       0.5000000000   0.0000000000   0.5000000000
+ Na3       0.5000000000   0.5000000000   0.0000000000
  Cl        0.5000000000   0.5000000000   0.5000000000
- Cl        0.5000000000   0.0000000000   0.0000000000
+ Clu       0.5000000000   0.0000000000   0.0000000000
  Cl        0.0000000000   0.5000000000   0.0000000000
- Cl        0.0000000000   0.0000000000   0.5000000000
+ Cld       0.0000000000   0.0000000000   0.5000000000
 """
     )
 
@@ -67,13 +66,13 @@ def test_cell2struct_and_read_qlm():
         fl1.write(sitex_ref.encode())
         fl1.close()
 
-        cell1 = read_qlm(fl1.name)
+        cell1, (inst1,) = read_qlm(fl1.name)
 
         fl2 = tempfile.NamedTemporaryFile(delete=False)
-        fl2.write(get_qlm_structure(cell1).encode())
+        fl2.write(inst1.to_site_str(cell1).encode())
         fl2.close()
 
-        cell2 = read_qlm(fl2.name)
+        cell2, _ = read_qlm(fl2.name)
 
         np.testing.assert_allclose(cell1.cell, cell2.cell, atol=1e-7)
         np.testing.assert_allclose(


### PR DESCRIPTION
     This change also relaxes a number of inconvenient restrictions:
    
    * Species names can have suffixes.
    * The input is not restricted to reduced coordinates anymore.
    * Output alat parameter is taken from the input file now.
