### PR TITLE
phonon dynamic structure factor: sign error in phase?

### DIFF
--- a/phonopy/spectrum/dynamic_structure_factor.py
+++ b/phonopy/spectrum/dynamic_structure_factor.py
@@ -228,7 +228,7 @@ class DynamicStructureFactor:
                     G_vector,
                     debye_waller,
                     f,
-                    eigvecs[:, i],
+                    eigvecs[:, i].conj(),
                 )
                 n = bose_einstein_dist(f, self._T)
                 S[i] = abs(F) ** 2 * (n + 1)


### PR DESCRIPTION
We observed some odd artifacts when calculating the dynamic structure factor systems like Ge or Si with a non-diagonal primitive matrix. The issue first occurs in phonopy v2.16.0 and we traced the artifacts to changing sign of the phase from
`np.exp(-2j * np.pi * np.dot(pos, G))` to `np.exp(2j * np.pi * np.dot(pos, G_vector))` in #211. 

The [documentation](https://phonopy.github.io/phonopy/dynamic-structure-factor.html) lists the phase as `Q+q` instead of `G=Q-q`. Making this change also eliminates the artifacts and appears more mathematically justified, but also changes the values of some old tests.

Considering the high bar for changing gold data, I'd appreciate the community's advice.