### PR TITLE
CIF writing: replace `get_volume()` with `volume`

### DIFF
--- a/phonopy/interface/cif.py
+++ b/phonopy/interface/cif.py
@@ -44,14 +44,14 @@ if TYPE_CHECKING:
     from phonopy.structure.atoms import PhonopyAtoms
 
 
-def write_cif_P1(cell : PhonopyAtoms, U_cif=None, filename=None):
+def write_cif_P1(cell: PhonopyAtoms, U_cif=None, filename=None):
     """Write P1 symmetry CIF file."""
     if filename:
         with open(filename, "w") as w:
             w.write(get_cif_P1(cell, U_cif=U_cif))
 
 
-def get_cif_P1(cell : PhonopyAtoms, U_cif=None):
+def get_cif_P1(cell: PhonopyAtoms, U_cif=None):
     """Return P1 symmetry CIF text."""
     a, b, c = get_cell_parameters(cell.cell)
     alpha, beta, gamma = get_angles(cell.cell)


### PR DESCRIPTION
With the replacement of the `PhonopyAtoms(...).get_volume()` function with the `volume` property, there was one remaining call to `get_volume()` in the CIF writing feature of phonopy (noted in [downstream CI test failure for atomate2](https://github.com/materialsproject/atomate2/actions/runs/18786897774/job/53607377809)). Updates the call and adds some type annotations