### PR TITLE
update atomic masses from ase.atomic_masses_iupac2016

### DIFF
--- a/phonopy/structure/atoms.py
+++ b/phonopy/structure/atoms.py
@@ -711,94 +711,117 @@ def parse_cell_dict(cell_dict: dict) -> PhonopyAtoms | None:
         return None
 
 
-# Atomic masses from ASE code are based on:
-#
-#   Meija, J., Coplen, T., Berglund, M., et al. (2016). Atomic weights of
-#   the elements 2013 (IUPAC Technical Report). Pure and Applied Chemistry,
-#   88(3), pp. 265-291. Retrieved 30 Nov. 2016,
-#   from doi:10.1515/pac-2015-0305
-#
-# Standard atomic weights are taken from Table 1: "Standard atomic weights
-# 2013", with the uncertainties ignored.
-# For hydrogen, helium, boron, carbon, nitrogen, oxygen, magnesium, silicon,
-# sulfur, chlorine, bromine and thallium, where the weights are given as a
-# range the "conventional" weights are taken from Table 3 and the ranges are
-# given in the comments.
-# The mass of the most stable isotope (in Table 4) is used for elements
-# where there the element has no stable isotopes (to avoid NaNs): Tc, Pm,
-# Po, At, Rn, Fr, Ra, Ac, everything after Np
+# Pure Appl. Chem., Vol. 83, No. 2, pp. 359-396, 2011. is available
+# but the following list is from 2006.
+
+# Pure Appl. Chem., Vol. 78, No. 11, pp. 2051-2066, 2006.
+# The masses of following elements are obtained from wikipedia:
+# Ac: 227
+# Np: 237
+# Pm: 145
+# Tc: 98
+# Po: 208.98243
+# At: 209.98715
+# Rn: 222.01758
+# Fr: 223.01974
+# Ra: 226.02541
+# Pu: 244.06421
+# Am: 243.06138
+# Cm: 247.07035
+# Bk: 247.07031
+# Cf: 247.07031
+# Es: 252.08300
+# Fm: 257.09511
+# Md: 258.09843
+# No: 259.1010
+# Lr: 262.110
+# Rf: 267.122
+# Db: 268.126
+# Sg: 271.134
+# Bh: 270.133
+# Hs: 269.1338
+# Mt: 278.156
+# Ds: 281.165
+# Rg: 281.166
+# Cn: 285.177
+# Nh: 286.182
+# Fl: 289.190
+# Mc: 289.194
+# Lv: 293.204
+# Ts: 293.208
+# Og: 294.214
 
 atom_data = [
-    [0, "X", "X", 1.0],  # 0
-    [1, "H", "Hydrogen", 1.008],  # 1
+    [0, "X", "X", None],  # 0
+    [1, "H", "Hydrogen", 1.00794],  # 1
     [2, "He", "Helium", 4.002602],  # 2
-    [3, "Li", "Lithium", 6.94],  # 3
-    [4, "Be", "Beryllium", 9.0121831],  # 4
-    [5, "B", "Boron", 10.81],  # 5
-    [6, "C", "Carbon", 12.011],  # 6
-    [7, "N", "Nitrogen", 14.007],  # 7
-    [8, "O", "Oxygen", 15.999],  # 8
-    [9, "F", "Fluorine", 18.998403163],  # 9
+    [3, "Li", "Lithium", 6.941],  # 3
+    [4, "Be", "Beryllium", 9.012182],  # 4
+    [5, "B", "Boron", 10.811],  # 5
+    [6, "C", "Carbon", 12.0107],  # 6
+    [7, "N", "Nitrogen", 14.0067],  # 7
+    [8, "O", "Oxygen", 15.9994],  # 8
+    [9, "F", "Fluorine", 18.9984032],  # 9
     [10, "Ne", "Neon", 20.1797],  # 10
     [11, "Na", "Sodium", 22.98976928],  # 11
-    [12, "Mg", "Magnesium", 24.305],  # 12
-    [13, "Al", "Aluminium", 26.9815385],  # 13
-    [14, "Si", "Silicon", 28.085],  # 14
-    [15, "P", "Phosphorus", 30.973761998],  # 15
-    [16, "S", "Sulfur", 32.06],  # 16
-    [17, "Cl", "Chlorine", 35.45],  # 17
+    [12, "Mg", "Magnesium", 24.3050],  # 12
+    [13, "Al", "Aluminium", 26.9815386],  # 13
+    [14, "Si", "Silicon", 28.0855],  # 14
+    [15, "P", "Phosphorus", 30.973762],  # 15
+    [16, "S", "Sulfur", 32.065],  # 16
+    [17, "Cl", "Chlorine", 35.453],  # 17
     [18, "Ar", "Argon", 39.948],  # 18
     [19, "K", "Potassium", 39.0983],  # 19
     [20, "Ca", "Calcium", 40.078],  # 20
-    [21, "Sc", "Scandium", 44.955908],  # 21
+    [21, "Sc", "Scandium", 44.955912],  # 21
     [22, "Ti", "Titanium", 47.867],  # 22
     [23, "V", "Vanadium", 50.9415],  # 23
     [24, "Cr", "Chromium", 51.9961],  # 24
-    [25, "Mn", "Manganese", 54.938044],  # 25
+    [25, "Mn", "Manganese", 54.938045],  # 25
     [26, "Fe", "Iron", 55.845],  # 26
-    [27, "Co", "Cobalt", 58.933194],  # 27
+    [27, "Co", "Cobalt", 58.933195],  # 27
     [28, "Ni", "Nickel", 58.6934],  # 28
     [29, "Cu", "Copper", 63.546],  # 29
     [30, "Zn", "Zinc", 65.38],  # 30
     [31, "Ga", "Gallium", 69.723],  # 31
-    [32, "Ge", "Germanium", 72.630],  # 32
-    [33, "As", "Arsenic", 74.921595],  # 33
-    [34, "Se", "Selenium", 78.971],  # 34
+    [32, "Ge", "Germanium", 72.64],  # 32
+    [33, "As", "Arsenic", 74.92160],  # 33
+    [34, "Se", "Selenium", 78.96],  # 34
     [35, "Br", "Bromine", 79.904],  # 35
     [36, "Kr", "Krypton", 83.798],  # 36
     [37, "Rb", "Rubidium", 85.4678],  # 37
     [38, "Sr", "Strontium", 87.62],  # 38
-    [39, "Y", "Yttrium", 88.90584],  # 39
+    [39, "Y", "Yttrium", 88.90585],  # 39
     [40, "Zr", "Zirconium", 91.224],  # 40
-    [41, "Nb", "Niobium", 92.90637],  # 41
-    [42, "Mo", "Molybdenum", 95.95],  # 42
-    [43, "Tc", "Technetium", 97.90721],  # 43
+    [41, "Nb", "Niobium", 92.90638],  # 41
+    [42, "Mo", "Molybdenum", 95.96],  # 42
+    [43, "Tc", "Technetium", 98],  # 43 (mass is from wikipedia)
     [44, "Ru", "Ruthenium", 101.07],  # 44
     [45, "Rh", "Rhodium", 102.90550],  # 45
     [46, "Pd", "Palladium", 106.42],  # 46
     [47, "Ag", "Silver", 107.8682],  # 47
-    [48, "Cd", "Cadmium", 112.414],  # 48
+    [48, "Cd", "Cadmium", 112.411],  # 48
     [49, "In", "Indium", 114.818],  # 49
     [50, "Sn", "Tin", 118.710],  # 50
     [51, "Sb", "Antimony", 121.760],  # 51
     [52, "Te", "Tellurium", 127.60],  # 52
     [53, "I", "Iodine", 126.90447],  # 53
     [54, "Xe", "Xenon", 131.293],  # 54
-    [55, "Cs", "Caesium", 132.90545196],  # 55
+    [55, "Cs", "Caesium", 132.9054519],  # 55
     [56, "Ba", "Barium", 137.327],  # 56
     [57, "La", "Lanthanum", 138.90547],  # 57
     [58, "Ce", "Cerium", 140.116],  # 58
-    [59, "Pr", "Praseodymium", 140.90766],  # 59
+    [59, "Pr", "Praseodymium", 140.90765],  # 59
     [60, "Nd", "Neodymium", 144.242],  # 60
-    [61, "Pm", "Promethium", 144.91276],  # 61
+    [61, "Pm", "Promethium", 145],  # 61 (mass is from wikipedia)
     [62, "Sm", "Samarium", 150.36],  # 62
     [63, "Eu", "Europium", 151.964],  # 63
     [64, "Gd", "Gadolinium", 157.25],  # 64
     [65, "Tb", "Terbium", 158.92535],  # 65
     [66, "Dy", "Dysprosium", 162.500],  # 66
-    [67, "Ho", "Holmium", 164.93033],  # 67
+    [67, "Ho", "Holmium", 164.93032],  # 67
     [68, "Er", "Erbium", 167.259],  # 68
-    [69, "Tm", "Thulium", 168.93422],  # 69
+    [69, "Tm", "Thulium", 168.93421],  # 69
     [70, "Yb", "Ytterbium", 173.054],  # 70
     [71, "Lu", "Lutetium", 174.9668],  # 71
     [72, "Hf", "Hafnium", 178.49],  # 72
@@ -809,45 +832,45 @@ atom_data = [
     [77, "Ir", "Iridium", 192.217],  # 77
     [78, "Pt", "Platinum", 195.084],  # 78
     [79, "Au", "Gold", 196.966569],  # 79
-    [80, "Hg", "Mercury", 200.592],  # 80
-    [81, "Tl", "Thallium", 204.38],  # 81
+    [80, "Hg", "Mercury", 200.59],  # 80
+    [81, "Tl", "Thallium", 204.3833],  # 81
     [82, "Pb", "Lead", 207.2],  # 82
     [83, "Bi", "Bismuth", 208.98040],  # 83
-    [84, "Po", "Polonium", 208.98243],  # 84
-    [85, "At", "Astatine", 209.98715],  # 85
-    [86, "Rn", "Radon", 222.01758],  # 86
-    [87, "Fr", "Francium", 223.01974],  # 87
-    [88, "Ra", "Radium", 226.02541],  # 88
-    [89, "Ac", "Actinium", 227.02775],  # 89
-    [90, "Th", "Thorium", 232.0377],  # 90
+    [84, "Po", "Polonium", 208.98243],  # 84 (mass is from wikipedia)
+    [85, "At", "Astatine", 209.98715],  # 85 (mass is from wikipedia)
+    [86, "Rn", "Radon", 222.01758],  # 86 (mass is from wikipedia)
+    [87, "Fr", "Francium", 223.01974],  # 87 (mass is from wikipedia)
+    [88, "Ra", "Radium", 226.02541],  # 88 (mass is from wikipedia)
+    [89, "Ac", "Actinium", 227],  # 89 (mass is from wikipedia)
+    [90, "Th", "Thorium", 232.03806],  # 90
     [91, "Pa", "Protactinium", 231.03588],  # 91
     [92, "U", "Uranium", 238.02891],  # 92
-    [93, "Np", "Neptunium", 237.04817],  # 93
-    [94, "Pu", "Plutonium", 244.06421],  # 94
-    [95, "Am", "Americium", 243.06138],  # 95
-    [96, "Cm", "Curium", 247.07035],  # 96
-    [97, "Bk", "Berkelium", 247.07031],  # 97
-    [98, "Cf", "Californium", 247.07031],  # 98
-    [99, "Es", "Einsteinium", 252.0830],  # 99
-    [100, "Fm", "Fermium", 257.09511],  # 100
-    [101, "Md", "Mendelevium", 258.09843],  # 101
-    [102, "No", "Nobelium", 259.1010],  # 102
-    [103, "Lr", "Lawrencium", 262.110],  # 103
-    [104, "Rf", "Rutherfordium", 267.122],  # 104
-    [105, "Db", "Dubnium", 268.126],  # 105
-    [106, "Sg", "Seaborgium", 271.134],  # 106
-    [107, "Bh", "Bohrium", 270.133],  # 107
-    [108, "Hs", "Hassium", 269.1338],  # 108
-    [109, "Mt", "Meitnerium", 278.156],  # 109
-    [110, "Ds", "Darmstadtium", 281.165],  # 110
-    [111, "Rg", "Roentgenium", 281.166],  # 111
-    [112, "Cn", "Copernicium", 285.177],  # 112
-    [113, "Nh", "Nihonium", 286.182],  # 113
-    [114, "Fl", "Flerovium", 289.190],  # 114
-    [115, "Mc", "Moscovium", 289.194],  # 115
-    [116, "Lv", "Livermorium", 293.204],  # 116
-    [117, "Ts", "Tennessine", 293.208],  # 117
-    [118, "Og", "Oganesson", 294.214],  # 118
+    [93, "Np", "Neptunium", 237],  # 93 (mass is from wikipedia)
+    [94, "Pu", "Plutonium", 244.06421],  # 94 (mass is from wikipedia)
+    [95, "Am", "Americium", 243.06138],  # 95 (mass is from wikipedia)
+    [96, "Cm", "Curium", 247.07035],  # 96 (mass is from wikipedia)
+    [97, "Bk", "Berkelium", 247.07031],  # 97 (mass is from wikipedia)
+    [98, "Cf", "Californium", 247.07031],  # 98 (mass is from wikipedia)
+    [99, "Es", "Einsteinium", 252.0830],  # 99 (mass is from wikipedia)
+    [100, "Fm", "Fermium", 257.09511],  # 100 (mass is from wikipedia)
+    [101, "Md", "Mendelevium", 258.09843],  # 101 (mass is from wikipedia)
+    [102, "No", "Nobelium", 259.1010],  # 102 (mass is from wikipedia)
+    [103, "Lr", "Lawrencium", 262.110],  # 103 (mass is from wikipedia)
+    [104, "Rf", "Rutherfordium", 267.122],  # 104 (mass is from wikipedia)
+    [105, "Db", "Dubnium", 268.126],  # 105 (mass is from wikipedia)
+    [106, "Sg", "Seaborgium", 271.134],  # 106 (mass is from wikipedia)
+    [107, "Bh", "Bohrium", 270.133],  # 107 (mass is from wikipedia)
+    [108, "Hs", "Hassium", 269.1338],  # 108 (mass is from wikipedia)
+    [109, "Mt", "Meitnerium", 278.156],  # 109 (mass is from wikipedia)
+    [110, "Ds", "Darmstadtium", 281.165],  # 110 (mass is from wikipedia)
+    [111, "Rg", "Roentgenium", 281.166],  # 111 (mass is from wikipedia)
+    [112, "Cn", "Copernicium", 285.177],  # 112 (mass is from wikipedia)
+    [113, "Nh", "Nihonium", 286.182],  # 113 (mass is from wikipedia)
+    [114, "Fl", "Flerovium", 289.190],  # 114 (mass is from wikipedia)
+    [115, "Mc", "Moscovium", 289.194],  # 115 (mass is from wikipedia)
+    [116, "Lv", "Livermorium", 293.204],  # 116 (mass is from wikipedia)
+    [117, "Ts", "Tennessine", 293.208],  # 117 (mass is from wikipedia)
+    [118, "Og", "Oganesson", 294.214],  # 118 (mass is from wikipedia)
 ]
 
 symbol_map = {


### PR DESCRIPTION
Due to incomplete atomic information in `atom_data`, and to improve consistency with ASE, I have updated the atomic masses to match those used in [ASE](https://gitlab.com/ase/ase/-/blob/master/ase/data/__init__.py).

The atomic mass data in ASE are based on:

[Meija, J., Coplen, T., Berglund, M., et al. (2016). *Atomic weights of the elements 2013 (IUPAC Technical Report)*. Pure and Applied Chemistry, 88(3), 265–291. doi:10.1515/pac-2015-0305](https://pure.mpg.de/rest/items/item_2251117/component/file_2261956/content)

As part of this update, many atomic masses that were previously copied from Wikipedia have been replaced with these standardized values.

