### PR TITLE
Update atol of tests about pypolymlp

### DIFF
--- a/test/api/test_api_phonopy.py
+++ b/test/api/test_api_phonopy.py
@@ -289,7 +289,7 @@ def test_mlp_NaCl_type2(ph_nacl_rd: Phonopy):
         4.894982489029413,
         5.46152086052448,
     ]
-    np.testing.assert_allclose(freqs.ravel(), freqs_ref, atol=1e-5)
+    np.testing.assert_allclose(freqs.ravel(), freqs_ref, atol=5e-5)
 
 
 def test_load_mlp_pypolymlp(ph_kcl: Phonopy):

--- a/test/interface/test_pypolymlp.py
+++ b/test/interface/test_pypolymlp.py
@@ -417,4 +417,4 @@ def test_pypolymlp_develop(ph_nacl_rd: Phonopy):
         4.888973568501199,
         5.4520357131954515,
     ]
-    np.testing.assert_allclose(freqs.ravel(), freqs_ref, atol=1e-6)
+    np.testing.assert_allclose(freqs.ravel(), freqs_ref, atol=5e-5)


### PR DESCRIPTION
Tests about pypolymlp are failed after the release of pypolymlp 0.18.0.

https://github.com/phonopy/phonopy/actions/runs/21795239798/job/62883294121

Let me update the atol used in the tests.