### PR TITLE
Correct spelling errors

### DIFF
--- a/phonopy/api_gruneisen.py
+++ b/phonopy/api_gruneisen.py
@@ -63,7 +63,7 @@ class PhonopyGruneisen:
         Parameters
         ----------
         phonon, phonon_plus, phonon_minus : Phonopy
-            Phonopy instances of the same crystal with differet volumes,
+            Phonopy instances of the same crystal with different volumes,
             V_0, V_0 + dV, V_0 - dV.
         delta_strain : float, optional
             Default is None, which gives dV / V_0.

--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -1059,7 +1059,7 @@ class Phonopy:
         level : int, optional
             Application of translational and permulation symmetries is
             repeated by this number. Default is 1.
-        show_drift : bool, optioanl
+        show_drift : bool, optional
             Drift forces are displayed when True. Default is True.
         use_symfc_projector : bool, optional
             If True, the force constants are symmetrized by symfc projector
@@ -1107,7 +1107,7 @@ class Phonopy:
 
         Parameters
         ----------
-        show_drift : bool, optioanl
+        show_drift : bool, optional
             Drift forces are displayed when True. Default is True.
 
         """
@@ -1144,7 +1144,7 @@ class Phonopy:
             Parameters for developing MLP. Default is None. When dict is given,
             PypolymlpParams instance is created from the dict.
         test_size : float, optional
-            Training and test data are splitted by this ratio. test_size=0.1
+            Training and test data are split by this ratio. test_size=0.1
             means the first 90% of the data is used for training and the rest
             is used for test. Default is 0.1.
 
@@ -1246,7 +1246,7 @@ class Phonopy:
         Returns
         -------
         frequencies: ndarray
-            Phonon frequencies. Imaginary frequenies are represented by
+            Phonon frequencies. Imaginary frequencies are represented by
             negative real numbers.
             shape=(bands, ), dtype='double'
 
@@ -1286,7 +1286,7 @@ class Phonopy:
         (frequencies, eigenvectors)
 
         frequencies: ndarray
-            Phonon frequencies. Imaginary frequenies are represented by
+            Phonon frequencies. Imaginary frequencies are represented by
             negative real numbers.
             shape=(bands, ), dtype='double', order='C'
         eigenvectors: ndarray
@@ -1342,7 +1342,7 @@ class Phonopy:
             False.
         is_band_connection : bool, optional
             Flag whether each band is connected or not. This is achieved by
-            comparing similarity of eigenvectors of neghboring poins. Sometimes
+            comparing similarity of eigenvectors of neighboring points. Sometimes
             this fails. Default is False.
         path_connections : List of bool, optional
             This is only used in graphical plot of band structure and gives
@@ -1401,7 +1401,7 @@ class Phonopy:
                 Distances in reciprocal space along paths.
                 shape=(q-points,), dtype='double'
             frequencies[i]: ndarray
-                Phonon frequencies. Imaginary frequenies are represented by
+                Phonon frequencies. Imaginary frequencies are represented by
                 negative real numbers.
                 shape=(q-points, bands), dtype='double'
             eigenvectors[i]: ndarray
@@ -1445,7 +1445,7 @@ class Phonopy:
         (default is False).
 
         npoints : int, optional
-            Number of q-points in each segment of band struture paths.
+            Number of q-points in each segment of band structure paths.
             The number includes end points. Default is 101.
         plot : Bool, optional
             With setting True, band structure is plotted using matplotlib and
@@ -1539,10 +1539,10 @@ class Phonopy:
         ----------
         comment : dict
             Data structure dumped in YAML and the dumped YAML text is put
-            at the beggining of the file.
+            at the beginning of the file.
         filename : str
             Default filename is 'band.yaml' when compression=None.
-            With compression, an extention of filename is added such as
+            With compression, an extension of filename is added such as
             'band.yaml.xz'.
         compression : None, 'gzip', or 'lzma'
             None gives usual text file. 'gzip and 'lzma' compresse yaml
@@ -1595,7 +1595,7 @@ class Phonopy:
             Time reversal symmetry is considered in symmetry search. By this,
             inversion symmetry is always included. Default is True.
         is_mesh_symmetry: bool, optional
-            Wheather symmetry search is done or not. Default is True
+            Whether symmetry search is done or not. Default is True
         with_eigenvectors: bool, optional
             Eigenvectors are stored by setting True. Default False.
         with_group_velocities : bool, optional
@@ -1718,7 +1718,7 @@ class Phonopy:
                 dtype='int64'
                 shape=(ir-grid points,)
             frequencies: ndarray
-                Phonon frequencies at ir-grid points. Imaginary frequenies are
+                Phonon frequencies at ir-grid points. Imaginary frequencies are
                 represented by negative real numbers.
                 dtype='double'
                 shape=(ir-grid points, bands)
@@ -1908,7 +1908,7 @@ class Phonopy:
             keys: frequencies, eigenvectors, and dynamical_matrices
 
             frequencies : ndarray
-                Phonon frequencies. Imaginary frequenies are represented by
+                Phonon frequencies. Imaginary frequencies are represented by
                 negative real numbers.
                 shape=(qpoints, bands), dtype='double'
             eigenvectors : ndarray
@@ -2267,7 +2267,7 @@ class Phonopy:
         ----------
         pdos_indices : list of list, optional
             Sets of indices of atoms whose projected DOS are summed over.
-            The indices start with 0. An example is as follwos:
+            The indices start with 0. An example is as follows:
                 pdos_indices=[[0, 1], [2, 3, 4, 5]]
             Default is None, which means
                 pdos_indices=[[i] for i in range(natom)]
@@ -2742,7 +2742,7 @@ class Phonopy:
         """Generate atomic displacements of phonon modes.
 
         The design of this feature is not very satisfactory, and thus API.
-        Therefore it should be reconsidered someday in the fugure.
+        Therefore it should be reconsidered someday in the future.
 
         Parameters
         ----------
@@ -2838,7 +2838,7 @@ class Phonopy:
     ) -> None:
         """Identify ir-reps of phonon modes.
 
-        The design of this API is not very satisfactory and is expceted
+        The design of this API is not very satisfactory and is expected
         to be redesined in the next major versions once the use case
         of the API for ir-reps feature becomes clearer.
 
@@ -3219,7 +3219,7 @@ class Phonopy:
             This specifies array shape of the force constants.
         with_nac : bool, optional
             Non-analytical term correction (NAC) is used under the Fourier
-            interpolation, i.e., dynamical matricies at commensurate points
+            interpolation, i.e., dynamical matrices at commensurate points
             are computed with NAC, then they are Fourier transform back to
             force constants of supercell_matrix. NAC parameters are not
             copied to returned Phonopy class instance.
@@ -3272,7 +3272,7 @@ class Phonopy:
         Returns
         -------
         ph : Phonopy
-            Copied phonopy class instace.
+            Copied phonopy class instance.
 
         """
         return self._copy(log_level=log_level)

--- a/phonopy/cui/collect_cell_info.py
+++ b/phonopy/cui/collect_cell_info.py
@@ -179,7 +179,7 @@ def collect_cell_info(
     When srystal structure search explained above failed, phonopy.yaml like file
     is searched in the current directory. phonopy.yaml like file name can be
     specified as the input crystal structure. Since phonopy.yaml like file
-    contains supercell and primitive cell matricies information, these
+    contains supercell and primitive cell matrices information, these
     parameter inputs of this function are ignored.
 
     Parameters
@@ -357,7 +357,7 @@ def _validate_cell(
                 '"%s"' % name for name in phonopy_yaml_cls.default_filenames[:-1]
             ]
             err_msg += [
-                '"%s" was read being prefered to files such as ' % unitcell_filename,
+                '"%s" was read being preferred to files such as ' % unitcell_filename,
                 '%s, or "%s".'
                 % (", ".join(filenames), phonopy_yaml_cls.default_filenames[-1]),
             ]

--- a/phonopy/cui/load.py
+++ b/phonopy/cui/load.py
@@ -155,7 +155,7 @@ def load(
         Input unit cell. Default is None.
     supercell : PhonopyAtoms, optional
         Input supercell. With given, default value of primitive_matrix is set to
-        'auto' (can be overwitten). supercell_matrix is ignored. Default is
+        'auto' (can be overwritten). supercell_matrix is ignored. Default is
         None.
     nac_params : dict, optional
         Parameters required for non-analytical term correction. Default is None.
@@ -184,7 +184,7 @@ def load(
     fc_calculator_options : str, optional
         Optional parameters that are passed to the external fc-calculator. This
         is given as one text string. How to parse this depends on the
-        fc-calculator. For alm, each parameter is splitted by comma ',', and
+        fc-calculator. For alm, each parameter is split by comma ',', and
         each set of key and value pair is written in 'key = value'.
     factor : float, optional
         Deprecated. Conversion factor is selected based off of `calculator`

--- a/phonopy/cui/phonopy_argparse.py
+++ b/phonopy/cui/phonopy_argparse.py
@@ -169,7 +169,7 @@ def get_parser(
         nargs="+",
         dest="band_indices",
         default=None,
-        help=("Band indices to be included to calcualte thermal properties"),
+        help=("Band indices to be included to calculate thermal properties"),
     )
     if not load_phonopy_yaml:
         parser.add_argument(

--- a/phonopy/cui/phonopy_gruneisen_script.py
+++ b/phonopy/cui/phonopy_gruneisen_script.py
@@ -298,7 +298,7 @@ def main(**argparse_control: PhonopyGruneisenMockArgs):
 
     if len(args.dirnames) != 3:
         sys.stderr.write(
-            "Three directory names (original, plus, minus) have to be spefied.\n"
+            "Three directory names (original, plus, minus) have to be specified.\n"
         )
         sys.exit(1)
 

--- a/phonopy/cui/phonopy_qha_script.py
+++ b/phonopy/cui/phonopy_qha_script.py
@@ -64,7 +64,7 @@ def get_options():
         "--eos",
         dest="eos",
         default=default_vals.eos,
-        help="Choise of EOS among vinet, birch_murnaghan, and murnaghan",
+        help="Choice of EOS among vinet, birch_murnaghan, and murnaghan",
     )
     parser.add_argument(
         "--exclude_imaginary",
@@ -186,7 +186,7 @@ def main(**argparse_control: PhonopyQHAMockArgs):
     # Show bulk modulus of v-e data
     if args.is_bulk_modulus_only:
         # if args.efe_file:
-        #     print("--efe optin can't be used with -b option")
+        #     print("--efe option can't be used with -b option")
         #     sys.exit(1)
         bulk_modulus = PhonopyQHA(
             volumes,
@@ -236,7 +236,7 @@ def main(**argparse_control: PhonopyQHAMockArgs):
     if len(volumes) != len(args.filenames[1:]):
         print(
             "The number of thermal_properites.yaml files (%d) "
-            "is inconsisten with" % len(args.filenames[1:])
+            "is inconsistent with" % len(args.filenames[1:])
         )
         print("the number of e-v data (%d)." % len(volumes))
         sys.exit(1)

--- a/phonopy/cui/phonopy_script.py
+++ b/phonopy/cui/phonopy_script.py
@@ -1395,7 +1395,7 @@ def _run_calculation(
                     plot.show()
 
         #
-        # Momemt
+        # Moment
         #
         elif settings.is_moment and run_mode in ("mesh", "band_mesh"):
             freq_min = settings.min_frequency

--- a/phonopy/cui/settings.py
+++ b/phonopy/cui/settings.py
@@ -369,7 +369,7 @@ class ConfParser:
             if opt_num_freqs:
                 self._confs["num_frequency_points"] = opt_num_freqs
 
-        # For backword compatibility
+        # For backward compatibility
         if "primitive_axis" in arg_list:
             if args.primitive_axis is not None:
                 if isinstance(args.primitive_axis, list):
@@ -1018,7 +1018,7 @@ class ConfParser:
         if "supercell_matrix" in params:
             settings.supercell_matrix = params["supercell_matrix"]
 
-        # Temperatures or temerature range
+        # Temperatures or temperature range
         if "tmax" in params:
             settings.max_temperature = params["tmax"]
         if "tmin" in params:

--- a/phonopy/file_IO.py
+++ b/phonopy/file_IO.py
@@ -410,7 +410,7 @@ def write_force_constants_to_hdf5(
         shape=(n_patom,)
         dtype=int64
     physical_unit : str, optional
-        Physical unit used for force contants. Default is None.
+        Physical unit used for force constants. Default is None.
     compression : str or int, optional
         h5py's lossless compression filters (e.g., "gzip", "lzf").
         See the detail at docstring of h5py.Group.create_dataset. Default is
@@ -538,7 +538,7 @@ def parse_disp_yaml(
 
     This method was originally made for parsing disp.yaml. Later this
     started to work for phonopy_disp.yaml, too. But now this method is not
-    allowed to read phonopy_disp.yaml because of existance of PhonopyYaml
+    allowed to read phonopy_disp.yaml because of existence of PhonopyYaml
     class.
 
     """
@@ -689,7 +689,7 @@ def parse_QPOINTS(filename="QPOINTS"):
 # BORN
 #
 def write_BORN(primitive, borns, epsilon, filename="BORN"):
-    """Write BORN from NAC paramters."""
+    """Write BORN from NAC parameters."""
     lines = get_BORN_lines(primitive, borns, epsilon)
     with open(filename, "w") as w:
         w.write("\n".join(lines))

--- a/phonopy/harmonic/dynamical_matrix.py
+++ b/phonopy/harmonic/dynamical_matrix.py
@@ -54,7 +54,7 @@ from phonopy.structure.cells import Primitive, sparse_to_dense_svecs
 class DynamicalMatrix:
     """Dynamical matrix base class.
 
-    When prmitive and supercell lattices are L_p and L_s, respectively,
+    When primitive and supercell lattices are L_p and L_s, respectively,
     frame F is defined by
     L_p = dot(F, L_s), then L_s = dot(F^-1, L_p).
     where lattice matrix is defined by axies a,b,c in Cartesian:
@@ -449,7 +449,7 @@ class DynamicalMatrixGL(DynamicalMatrixNAC):
             default and the reasonable choice.
         decimals : int, optional, default=None
             Number of decimals. Use like dm.round(decimals).
-        log_levelc : int, optional, defualt=0
+        log_levelc : int, optional, default=0
             Log level.
         use_openmp : bool, optional, default=False
             Use OpenMP in calculate dynamical matrix.
@@ -818,7 +818,7 @@ class DynamicalMatrixGL(DynamicalMatrixNAC):
         return g_rad
 
     def _get_G_vec_list(self, g_rad: int) -> NDArray[np.double]:
-        """Return reciprocal lattice point vectors withing g_rad cutoff.
+        """Return reciprocal lattice point vectors within g_rad cutoff.
 
         With g_rad = 2,
         grid.T = [[-2, -2, -2],
@@ -830,7 +830,7 @@ class DynamicalMatrixGL(DynamicalMatrixNAC):
                   [-1, -2, -1],
                   ...]
 
-        The implmentation using meshgrid may be unstable at numpy 2.0.
+        The implementation using meshgrid may be unstable at numpy 2.0.
         Therefore, another way is used although it can be slower.
 
         """
@@ -911,7 +911,7 @@ class DynamicalMatrixWang(DynamicalMatrixNAC):
             dtype='double'
         decimals : int, optional, default=None
             Number of decimals. Use like dm.round(decimals).
-        log_levelc : int, optional, defualt=0
+        log_levelc : int, optional, default=0
             Log level.
         use_openmp : bool, optional, default=False
             Use OpenMP in calculate dynamical matrix.
@@ -1002,7 +1002,7 @@ class DynamicalMatrixWang(DynamicalMatrixNAC):
         N = len(self._scell) // len(self._pcell)
         for s1 in range(len(self._scell)):
             # This if-statement is the trick.
-            # In contructing dynamical matrix in phonopy
+            # In constructing dynamical matrix in phonopy
             # fc of left indices with s1 == self._s2p_map[ s1 ] are
             # only used.
             if s1 != self._s2p_map[s1]:
@@ -1027,7 +1027,7 @@ def get_dynamical_matrix(
     """Return dynamical matrix.
 
     The instance of a class inherited from DynamicalMatrix will be returned
-    depending on paramters.
+    depending on parameters.
 
     """
     if frequency_scale_factor is None:
@@ -1075,7 +1075,7 @@ def run_dynamical_matrix_solver_c(
     is_nac: bool | None = None,
     hermitianize: bool = True,
 ) -> NDArray[np.cdouble]:
-    """Bulid and solve dynamical matrices on grid in C-API.
+    """Build and solve dynamical matrices on grid in C-API.
 
     If dynamical matrices at many qpoints are calculated, it is recommended not
     to use this function one qpoint by one qpoint to avoid overhead in the

--- a/phonopy/harmonic/dynmat_to_fc.py
+++ b/phonopy/harmonic/dynmat_to_fc.py
@@ -157,7 +157,7 @@ def ph2fc(
     supercell_matrix : array_like
         This specifies array shape of the force constants.
     with_nac : bool, optional
-        Use non-analytical term correction if NAC paramerters exist. Default is
+        Use non-analytical term correction if NAC parameters exist. Default is
         True.
 
     Returns
@@ -314,16 +314,16 @@ class DynmatToForceConstants:
 
         if dynamical_matrices is not None or commensurate_points is not None:
             warnings.warn(
-                "Instanciation init parameters of dynamical_matrices"
+                "Instantiation init parameters of dynamical_matrices"
                 " and commensurate_points are deprecated. Use "
-                "respecitve attributes.",
+                "respective attributes.",
                 DeprecationWarning,
                 stacklevel=2,
             )
 
         if eigenvalues is not None or eigenvectors is not None:
             warnings.warn(
-                "Instanciation init parameters of eigenvalues and "
+                "Instantiation init parameters of eigenvalues and "
                 "eigenvectors are deprecated. Use "
                 "create_dynamical_matrices method.",
                 DeprecationWarning,

--- a/phonopy/harmonic/force_constants.py
+++ b/phonopy/harmonic/force_constants.py
@@ -895,7 +895,7 @@ def _get_atom_indices_by_symmetry(
     K = len(positions)
     # positions[K, 3]
     # dot()[K, N, 3] where N is number of sym opts.
-    # translation[N, 3] is added to the last two dimenstions after dot().
+    # translation[N, 3] is added to the last two dimensions after dot().
     rpos = np.dot(positions, np.transpose(rotations, (0, 2, 1))) + translations
 
     # np.tile(rpos, (K, 1, 1, 1))[K(2), K(1), N, 3]

--- a/phonopy/interface/castep.py
+++ b/phonopy/interface/castep.py
@@ -227,7 +227,7 @@ class CastepIn:
                     if "ENDBLOCK" in lines[i].upper():
                         break
                     if "BOHR" in lines[i].upper():
-                        # The lattice vector units is Bohr. Convertion needed.
+                        # The lattice vector units is Bohr. Conversion needed.
                         units = 0.529177211
                     elif len(lines[i].split()) >= 3:
                         lattvecs.append(

--- a/phonopy/interface/pypolymlp.py
+++ b/phonopy/interface/pypolymlp.py
@@ -58,7 +58,7 @@ except ImportError:
 class PypolymlpParams:
     """Parameters for pypolymlp.
 
-    cutoff : flaot, optional
+    cutoff : float, optional
         Cutoff radius. Default is 8.0.
     model_type : int, optional
         Polynomial function type. Default is 3. model_type = 1: Linear

--- a/phonopy/interface/turbomole.py
+++ b/phonopy/interface/turbomole.py
@@ -189,7 +189,7 @@ class TurbomoleIn:
             #      2.58949092075      2.58949092075      2.58949092075      si
             elif "$coord" in line:
                 if line.strip() == "$coord":
-                    # Embdedded coordinates.
+                    # Embedded coordinates.
                     ll += 1
                     while ll < len(lines):
                         atom = lines[ll].split()

--- a/phonopy/interface/vasp.py
+++ b/phonopy/interface/vasp.py
@@ -1130,12 +1130,12 @@ class VasprunxmlExpat:
 
     @property
     def fft_grid(self) -> list[int]:
-        """Return FFT gird [NGX, NGY, NGZ]."""
+        """Return FFT grid [NGX, NGY, NGZ]."""
         return self._fft_grid
 
     @property
     def fft_fine_grid(self) -> list[int]:
-        """Return fine FFT gird [NGXF, NGYF, NGZF]."""
+        """Return fine FFT grid [NGXF, NGYF, NGZF]."""
         return self._fft_fine_grid
 
     @property

--- a/phonopy/interface/wien2k.py
+++ b/phonopy/interface/wien2k.py
@@ -382,7 +382,7 @@ def _distribute_forces(supercell, disp, forces, filename, symprec):
         if len(forces_remap) != len(forces):
             print("Atomic position mapping between Wien2k and phonopy failed.")
             print("If you think this is caused by a bug of phonopy")
-            print("please report it in the phonopy mainling list.")
+            print("please report it in the phonopy mailing list.")
             return False
 
         # 2. Distribute forces from independent to dependent atoms.

--- a/phonopy/phonon/band_structure.py
+++ b/phonopy/phonon/band_structure.py
@@ -260,7 +260,7 @@ class BandStructure:
             dtype='double'
             shape=(qpoints on a path, 3)
     frequencies: list of ndarray
-        Phonon frequencies. Imaginary frequenies are represented by negative
+        Phonon frequencies. Imaginary frequencies are represented by negative
         real numbers.
         Each ndarray corresponding to each q-path has
             dtype='double'
@@ -324,7 +324,7 @@ class BandStructure:
             Flag whether eigenvectors are calculated or not. Default is False.
         is_band_connection : bool, optional
             Flag whether each band is connected or not. This is achieved by
-            comparing similarity of eigenvectors of neghboring poins. Sometimes
+            comparing similarity of eigenvectors of neghboring points. Sometimes
             this fails. Default is False.
         group_velocity : GroupVelocity, optional
             Group velocity calculator. Default is None.
@@ -583,10 +583,10 @@ class BandStructure:
         ----------
         comment : dict
             Data structure dumped in YAML and the dumped YAML text is put
-            at the beggining of the file.
+            at the beginning of the file.
         filename : str
             Default filename is 'band.yaml' when compression=None.
-            With compression, an extention of filename is added such as
+            With compression, an extension of filename is added such as
             'band.yaml.xz'.
         compression : None, 'gzip', or 'lzma'
             None gives usual text file. 'gzip and 'lzma' compresse yaml

--- a/phonopy/phonon/irreps.py
+++ b/phonopy/phonon/irreps.py
@@ -62,7 +62,7 @@ class IrReps:
     - Group theory with applications in chemical physics by Patrick Jacobs
     - Symmetry and condensed matter physics by M. El-Batanouny and F. Wooten
 
-    Magnetic space group is not supportd.
+    Magnetic space group is not supported.
 
     """
 

--- a/phonopy/phonon/mesh.py
+++ b/phonopy/phonon/mesh.py
@@ -196,7 +196,7 @@ class Mesh(MeshBase):
     Attributes
     ----------
     frequencies: ndarray
-        Phonon frequencies at ir-grid points. Imaginary frequenies are
+        Phonon frequencies at ir-grid points. Imaginary frequencies are
         represented by negative real numbers.
         dtype='double'
         shape=(ir-grid points, bands)
@@ -250,7 +250,7 @@ class Mesh(MeshBase):
         """Define iterator over q-points.
 
         Initially, all phonons are computed and stored in arrays.
-        Then this is just used as an iterator to return exisiting results.
+        Then this is just used as an iterator to return existing results.
         The purpose of this iterator is compatible use of IterMesh.
 
         """

--- a/phonopy/phonon/moment.py
+++ b/phonopy/phonon/moment.py
@@ -77,7 +77,7 @@ class PhononMoment:
         freq_max: float | None = None,
         tolerance: float = 1e-8,
     ) -> None:
-        """Set frequeny range where moment is computed."""
+        """Set frequency range where moment is computed."""
         if freq_min is None:
             self._fmin = tolerance
         else:

--- a/phonopy/phonon/qpoints.py
+++ b/phonopy/phonon/qpoints.py
@@ -68,14 +68,14 @@ class QpointsPhonon:
     Attributes
     ----------
     frequencies : ndarray
-        Phonon frequencies. Imaginary frequenies are represented by
-        negative real numbers. Unit conversion factor is multipled.
+        Phonon frequencies. Imaginary frequencies are represented by
+        negative real numbers. Unit conversion factor is multiplied.
         shape=(qpoints, bands), dtype='double'
     eigenvectors : ndarray
         Phonon eigenvectors. None when with_eigenvectors=False.
         shape=(qpoints, bands, bands), dtype='complex'
     eigenvalues : ndarray
-        Phonon eigenvvalues. Unit conversion factor is not multipled.
+        Phonon eigenvvalues. Unit conversion factor is not multiplied.
         shape=(qpoints, bands), dtype='double'
     group_velocities : ndarray
         Phonon group velocities. None if group velocities are not

--- a/phonopy/phonon/random_displacements.py
+++ b/phonopy/phonon/random_displacements.py
@@ -240,7 +240,7 @@ class RandomDisplacements:
         self._uu: NDArray[np.double] | None = None
         self._uu_inv: NDArray[np.double] | None = None
 
-        # Phonon bands included in integration of dispalcements.
+        # Phonon bands included in integration of displacements.
         self._conditions_ii: NDArray[np.bool_] | None = None
         self._conditions_ij: NDArray[np.bool_] | None = None
 
@@ -336,8 +336,8 @@ class RandomDisplacements:
     def frequencies(self) -> NDArray[np.double]:
         """Setter and getter of phonon frequencies.
 
-        Phonon frequences themselves are not stored in this instance, but are
-        stored in a way of eigenvalues. The eigenvalues can be stored vai
+        Phonon frequencies themselves are not stored in this instance, but are
+        stored in a way of eigenvalues. The eigenvalues can be stored via
         frequencies setter attributed.
 
         """

--- a/phonopy/phonon/tetrahedron_mesh.py
+++ b/phonopy/phonon/tetrahedron_mesh.py
@@ -67,7 +67,7 @@ class TetrahedronMesh:
         cell : PhonopyAtoms
             Primitive cell used to calculate frequencies
         frequencies: ndarray
-            Phonon frequences on ir-grid points
+            Phonon frequencies on ir-grid points
             shape=(num_ir_grid_points, num_band)
             dtype='double'
         mesh : ndarray or list of int
@@ -84,7 +84,7 @@ class TetrahedronMesh:
             shape=(prod(mesh),)
             dtype='int64'
         ir_grid_points : ndarray
-            Irreducible gird points given by GridPoints class.
+            Irreducible grid points given by GridPoints class.
             shape=(len(np.unique(grid_mapping_table)),)
             dtype='int64'
         grid_order : list of int, optional
@@ -126,7 +126,7 @@ class TetrahedronMesh:
         return self
 
     def __next__(self) -> NDArray[np.double]:
-        """Peform linear tetrahedron method at a grid point."""
+        """Perform linear tetrahedron method at a grid point."""
         if self._tm is None:
             raise RuntimeError("Tetrahedron method is not set yet.")
         if self._grid_point_count == len(self._ir_grid_points):
@@ -171,7 +171,7 @@ class TetrahedronMesh:
         frequency_points: NDArray[np.double] | None = None,
         lang: Literal["C", "Python"] = "C",
     ) -> None:
-        """Prepare environment to peform linear tetrahedron method."""
+        """Prepare environment to perform linear tetrahedron method."""
         self._grid_point_count = 0
         self._value: Literal["I", "J"] = value
         if frequency_points is None:
@@ -233,7 +233,7 @@ def get_tetrahedra_frequencies(
         dimension of frequencies. The ir-grid index is
         range(len(ir-grid-points)). shape=(prod(mesh), ), dtype='int64'
     frequencies : ndarray
-        Phonon frequences on ir-grid points. shape=(ir-grid-points, num_band)
+        Phonon frequencies on ir-grid points. shape=(ir-grid-points, num_band)
         dtype='double'
     grid_order : list of int, optional
         This controls how grid addresses are stored either C style or Fortran

--- a/phonopy/phonon/thermal_displacement.py
+++ b/phonopy/phonon/thermal_displacement.py
@@ -190,9 +190,9 @@ class ThermalDisplacements(ThermalMotion):
             Eigenvector projection direction in Cartesian
             coordinates. If None, eigenvector is not projected.
         freq_min:
-            Minimum phonon frequency to determine wheather include or not.
+            Minimum phonon frequency to determine whether include or not.
         freq_max:
-            Maximum phonon frequency to determine wheather include or not.
+            Maximum phonon frequency to determine whether include or not.
 
         """
         super().__init__(iter_mesh, freq_min=freq_min, freq_max=freq_max)
@@ -318,9 +318,9 @@ class ThermalDisplacementMatrices(ThermalMotion):
             symmetry, i.e., IterMesh instance has to be create
             ``is_mesh_symmetry=False``.
         freq_min: float
-            Minimum phonon frequency to determine wheather include or not.
+            Minimum phonon frequency to determine whether include or not.
         freq_max: float
-            Maximum phonon frequency to determine wheather include or not.
+            Maximum phonon frequency to determine whether include or not.
         lattice: array_like
             Lattice parameters (column vectors) in real space
             dtype='double', shape=(3, 3)

--- a/phonopy/qha/core.py
+++ b/phonopy/qha/core.py
@@ -377,7 +377,7 @@ class QHA:
         parameters = []
         free_energies = []
 
-        for i in range(num_elems):  # loop over temperaturs
+        for i in range(num_elems):  # loop over temperatures
             if self._electronic_energies.ndim == 1:
                 el_energy = self._electronic_energies
             else:
@@ -430,7 +430,7 @@ class QHA:
 
         # For computing following values at temperatures, finite difference
         # method is used. Therefore number of temperature points are needed
-        # larger than self._num_elems that nearly equals to the temparature
+        # larger than self._num_elems that nearly equals to the temperature
         # point we expect.
         self._set_thermal_expansion()
         self._set_heat_capacity_P_numerical()
@@ -805,7 +805,7 @@ class QHA:
                 )
 
     def get_heat_capacity_P_numerical(self) -> NDArray[np.double]:
-        """Return C_P by numerical differenciation at temperatures."""
+        """Return C_P by numerical differentiation at temperatures."""
         return self.heat_capacity_P_numerical
 
     def plot_heat_capacity_P_numerical(

--- a/phonopy/scripts/phonopy_calc_convert.py
+++ b/phonopy/scripts/phonopy_calc_convert.py
@@ -155,9 +155,9 @@ def parse_fleur(opts):
     r"""Parse additional info used in fleur.
 
     fleur:
-        additional_info is a list of atom lables. They are either Z or Z.x,
+        additional_info is a list of atom labels. They are either Z or Z.x,
         where Z is the atomic number and x is any number of decimal places.
-        After this list of lables, A single string of additional lines
+        After this list of labels, A single string of additional lines
         (separated by \n) with job information can be given to be added to output file.
 
         eg. '13.0 13.0 13.1 "Title \n Additional job info here \n"'

--- a/phonopy/scripts/phonopy_pdosplot.py
+++ b/phonopy/scripts/phonopy_pdosplot.py
@@ -40,7 +40,7 @@
 # The axis resolved PDOS is summed up with the successive
 # indices separated by ",". In this example, indices 1 and
 # 2, 3 and 4 are summed respectively, and then they are
-# ploted respectively.
+# plotted respectively.
 #
 # The indices are defined like:
 # 1 2 3 : X Y Z of the 1st atom,

--- a/phonopy/scripts/phonopy_tdplot.py
+++ b/phonopy/scripts/phonopy_tdplot.py
@@ -40,9 +40,9 @@
 # The axis resolved thermal displacements are averaged by root mean
 # square with the successive indices separated by ",". In this
 # example, values at a temperature with the indices 1 and 2, 3 and 4
-# are averaged by root mean square respectively as follwos:
+# are averaged by root mean square respectively as follows:
 #   sqrt( ( x_1 ** 2 + x_2 ** 2 + x_3 ** 2 + x_4 ** 2 ) / 4 ),
-# and then they are ploted as a function of temperature.
+# and then they are plotted as a function of temperature.
 #
 # The definition is that indices correspond to those as follows:
 # 1 2 3 : X Y Z of the 1st atom,

--- a/phonopy/spectrum/dynamic_structure_factor.py
+++ b/phonopy/spectrum/dynamic_structure_factor.py
@@ -87,7 +87,7 @@ class DynamicStructureFactor:
     Neutron scattering length
     -------------------------
     https://www.ncnr.nist.gov/resources/n-lengths/
-    Exmple: {'Na': 3.63,
+    Example: {'Na': 3.63,
              'Cl': 9.5770}
 
     Attributes
@@ -145,9 +145,9 @@ class DynamicStructureFactor:
             Coherent scattering lengths averaged over isotopes and spins.
             Supposed for INS. For example, {'Na': 3.63, 'Cl': 9.5770}.
         freq_min: float
-            Minimum phonon frequency to determine wheather include or not.
+            Minimum phonon frequency to determine whether include or not.
         freq_max: float
-            Maximum phonon frequency to determine wheather include or not. Only
+            Maximum phonon frequency to determine whether include or not. Only
             for Debye-Waller factor.
 
         """
@@ -293,7 +293,7 @@ class DynamicStructureFactor:
         """Return F(Q, q nu).
 
         The phase factor is different by exp(iq.r) from that of the book
-        "Thermal neutron scattering" because of different difinition of
+        "Thermal neutron scattering" because of different definition of
         dynamical matrix.
 
         """

--- a/phonopy/structure/cells.py
+++ b/phonopy/structure/cells.py
@@ -106,7 +106,7 @@ class Supercell(PhonopyAtoms):
             elements have to be integers.
             shape=(3,3)
         is_old_stype: bool
-            This swithes the algorithms. See Note.
+            This switches the algorithms. See Note.
         symprec: float, optional
             Tolerance to find overlapping atoms in supercell cell. The default
             values is 1e-5.
@@ -424,7 +424,7 @@ class Primitive(PhonopyAtoms):
         """Return shortest vectors and multiplicities.
 
         See also the docstring of `ShortestPairs`. The older less densen format
-        is deprecated. The detailed explaination is found in `ShortestPairs`
+        is deprecated. The detailed explanation is found in `ShortestPairs`
         class.
 
         Returns
@@ -648,7 +648,7 @@ class TrimmedCell(PhonopyAtoms):
 
     @property
     def mapping_table(self) -> NDArray[np.int64]:
-        """Return mappping table.
+        """Return mapping table.
 
         mapping_table : ndarray
             The atomic indices of 'extracted_atom's of all atoms in the input
@@ -1074,7 +1074,7 @@ def get_reduced_bases(
         delaunay: Delaunay reduction
         niggli: Niggli reduction
     tolerance : float
-        Tolerance to find shortest basis vecotrs
+        Tolerance to find shortest basis vectors
 
     Returns
     -------
@@ -1157,7 +1157,7 @@ class ShortestPairs:
             dtype='double', shape=(size_super, 3)
         primitive_pos : array_like
             Atomic positions in fractional coordinates of supercell. Note that
-            not in fractional coodinates of primitive cell.  dtype='double',
+            not in fractional coordinates of primitive cell.  dtype='double',
             shape=(size_prim, 3)
         store_dense_svecs_: bool, optional
             ``shortest_vectors`` are stored in the dense data structure.

--- a/phonopy/structure/grid_points.py
+++ b/phonopy/structure/grid_points.py
@@ -250,7 +250,7 @@ class GridPoints:
             dtype='int64'
             shape=(rotations, 3, 3)
         is_mesh_symmetry: bool, optional, default True
-            Wheather symmetry search is done or not.
+            Whether symmetry search is done or not.
 
         """
         self._mesh = np.array(mesh_numbers, dtype="int64")
@@ -337,7 +337,7 @@ class GridPoints:
         Parameters
         ----------
         tolerance : float
-            This is used to judge zero/half gird shift.
+            This is used to judge zero/half grid shift.
 
         """
         if q_mesh_shift is None:

--- a/phonopy/structure/snf.py
+++ b/phonopy/structure/snf.py
@@ -183,7 +183,7 @@ class SNF3x3:
         return -1
 
     def _first_finalize(self) -> None:
-        """Set zeros along the first colomn except for A[0, 0].
+        """Set zeros along the first column except for A[0, 0].
 
         This is possible only when A[1,0] and A[2,0] are dividable by A[0,0].
 

--- a/phonopy/structure/symmetry.py
+++ b/phonopy/structure/symmetry.py
@@ -557,20 +557,20 @@ def symmetrize_borns_and_epsilon(
     primitive : PhonopyAtoms
         This is an alternative of giving primitive_matrix (Mp). Mp is given as
             Mp = (a_u, b_u, c_u)^-1 * (a_p, b_p, c_p).
-        In addition, the order of atoms is alined to those of atoms in this
+        In addition, the order of atoms is aligned to those of atoms in this
         primitive cell for Born effective charges. No rigid rotation of
         crystal structure is assumed.
     supercell_matrix: array_like, optional
         Supercell matrix. This is used to select Born effective charges in
         **primitive cell**. Supercell matrix is needed because primitive
         cell is created first creating supercell from unit cell, then
-        the primitive cell is created from the supercell. If None (defautl),
+        the primitive cell is created from the supercell. If None (default),
         1x1x1 supercell is created.
         shape=(3, 3)
         dtype='int'
     symprec: float, optional
         Symmetry tolerance. Default is 1e-5
-    is_symmetry: bool, optinal
+    is_symmetry: bool, optional
         By setting False, symmetrization can be switched off. Default is True.
 
     """

--- a/phonopy/unfolding/core.py
+++ b/phonopy/unfolding/core.py
@@ -117,7 +117,7 @@ class Unfolding:
             shape=(3, 3), dtype='double'
         atom_mapping : list
             Atomic index mapping from ``ideal_positions`` to supercell atoms
-            in ``phonon``. The elements of this list are intergers for atoms
+            in ``phonon``. The elements of this list are integers for atoms
             and None for vacancies.
         qpoints : array_like
             q-points in reciprocal virtual-primitive-cell coordinates


### PR DESCRIPTION
I've used codespell to identify spelling errors in phonopy/ folder.
Correct all spelling errors, codespell still complains about some words but that are not errors, except probably `lables` around phonopy/interface/lammps.py:357, but I didn't want to modify actual code.

Command:
`uvx codespell phonopy`