### PR TITLE
Support hdf5 saving

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -3146,15 +3146,19 @@ class Phonopy:
         self,
         filename: str | os.PathLike = "phonopy_params.yaml",
         settings: dict | None = None,
-        hdf5_settings: dict | None = None,
         compression: str | bool = False,
     ) -> str:
         """Save phonopy parameters into file.
 
+        The output format is determined by the filename extension:
+        - ``.yaml`` or ``.yml``: YAML format (optionally xz-compressed).
+        - ``.hdf5``: Self-contained HDF5 file with structure metadata
+          embedded as YAML and force constants / force sets as binary datasets.
+
         Parameters
         ----------
         filename: str, optional
-            File name. Default is "phonopy_params.yaml"
+            File name. Default is "phonopy_params.yaml".
         settings: dict, optional
             It is described which parameters are written out. Only the settings
             expected to be updated from the following default settings are
@@ -3166,28 +3170,28 @@ class Phonopy:
             This default settings are updated by {'force_constants': True} when
             dataset is None and force_constants is not None unless
             {'force_constants': False} is specified.
-        hdf5_settings: dict, optional (To be implemented)
-            Force constants and force_sets are stored in hdf5 file when they are
-            activated in the dict. The dict has the following keys. The default
-            filename is the filename of yaml file where '.yaml' is replaced by
-            '.hdf5'.
-                'filename' : str 'force_constants': bool (default=False)
-                'force_sets': bool (default=False)
         compression : bool or str
-            If True, phonopy_params.yaml like file is compressed by xz. When
-            compression=='xz', the file is compressed by xz. Default is False.
+            For YAML output: if True or 'xz', the file is compressed by xz.
+            Default is False. Ignored for HDF5 output.
 
         Returns
         -------
         str :
-            File name of the saved phonopy_params.yaml like file. If it is
-            compressed,
+            File name of the saved file.
 
         """
-        if hdf5_settings is not None:
-            msg = "hdf5_settings parameter has not yet been implemented."
-            raise NotImplementedError(msg)
+        if str(filename).endswith(".hdf5"):
+            return self._save_as_hdf5(filename, settings)
 
+        return self._save_as_yaml(filename, settings, compression)
+
+    def _save_as_yaml(
+        self,
+        filename: str | os.PathLike,
+        settings: dict | None,
+        compression: str | bool,
+    ) -> str:
+        """Save phonopy parameters as YAML."""
         if settings is None:
             _settings = {}
         else:
@@ -3209,6 +3213,145 @@ class Phonopy:
                 w.write(str(phpy_yaml))
 
         return out_filename
+
+    def _save_as_hdf5(
+        self,
+        filename: str | os.PathLike,
+        settings: dict | None,
+    ) -> str:
+        """Save all phonopy parameters into a self-contained HDF5 file.
+
+        All data is stored as native HDF5 datasets and attributes with a
+        structure mirroring the YAML format.
+
+        """
+        try:
+            import h5py
+        except ImportError as exc:
+            raise ModuleNotFoundError("You need to install python-h5py.") from exc
+
+        if settings is None:
+            _settings = {}
+        else:
+            _settings = settings.copy()
+        if _settings.get("force_constants") is False:
+            pass
+        elif not forces_in_dataset(self.dataset) and self.force_constants is not None:
+            _settings.update({"force_constants": True})
+
+        out_filename = str(filename)
+        with h5py.File(out_filename, "w") as w:
+            # Header
+            phgrp = w.create_group("phonopy")
+            phgrp.attrs["version"] = __version__
+            if self.calculator is not None:
+                phgrp.attrs["calculator"] = self.calculator
+
+            # Unit cell
+            uc_grp = w.create_group("unit_cell")
+            uc_grp.create_dataset("lattice", data=self.unitcell.cell)
+            uc_grp.create_dataset(
+                "coordinates", data=self.unitcell.scaled_positions
+            )
+            uc_grp.create_dataset("masses", data=self.unitcell.masses)
+            uc_grp.create_dataset(
+                "symbols",
+                data=np.array(self.unitcell.symbols, dtype="S"),
+            )
+            uc_grp.create_dataset("numbers", data=self.unitcell.numbers)
+
+            # Supercell matrix
+            w.create_dataset("supercell_matrix", data=self.supercell_matrix)
+
+            # Primitive matrix
+            if self.primitive_matrix is not None:
+                w.create_dataset("primitive_matrix", data=self.primitive_matrix)
+
+            # NAC parameters
+            nac = self.nac_params
+            if nac is not None:
+                nac_grp = w.create_group("nac")
+                if (
+                    "born" in nac
+                    and _settings.get("born_effective_charge", True)
+                ):
+                    nac_grp.create_dataset("born", data=nac["born"])
+                if (
+                    "dielectric" in nac
+                    and _settings.get("dielectric_constant", True)
+                ):
+                    nac_grp.create_dataset(
+                        "dielectric", data=nac["dielectric"]
+                    )
+                if "factor" in nac:
+                    nac_grp.attrs["factor"] = nac["factor"]
+
+            # Force constants
+            if self.force_constants is not None and _settings.get(
+                "force_constants", False
+            ):
+                w.create_dataset("force_constants", data=self.force_constants)
+                w.create_dataset("p2s_map", data=self.primitive.p2s_map)
+
+            # Force sets
+            if self.dataset is not None and forces_in_dataset(self.dataset):
+                grp = w.create_group("force_sets")
+                self._write_force_sets_to_hdf5_group(grp, self.dataset)
+
+        return out_filename
+
+    @staticmethod
+    def _write_force_sets_to_hdf5_group(
+        grp: Any,
+        dataset: dict,
+        compression: str | None = None,
+    ) -> None:
+        """Write force sets data into an hdf5 group."""
+        if "first_atoms" in dataset:
+            grp.attrs["dataset_type"] = 1
+            grp.attrs["natom"] = dataset["natom"]
+            numbers = np.array(
+                [d["number"] for d in dataset["first_atoms"]], dtype="int32"
+            )
+            displacements = np.array(
+                [d["displacement"] for d in dataset["first_atoms"]], dtype="double"
+            )
+            grp.create_dataset("numbers", data=numbers, compression=compression)
+            grp.create_dataset(
+                "displacements", data=displacements, compression=compression
+            )
+            if "forces" in dataset["first_atoms"][0]:
+                forces = np.array(
+                    [d["forces"] for d in dataset["first_atoms"]], dtype="double"
+                )
+                grp.create_dataset("forces", data=forces, compression=compression)
+            if "supercell_energy" in dataset["first_atoms"][0]:
+                energies = np.array(
+                    [d["supercell_energy"] for d in dataset["first_atoms"]],
+                    dtype="double",
+                )
+                grp.create_dataset(
+                    "supercell_energies", data=energies, compression=compression
+                )
+        elif "displacements" in dataset:
+            grp.attrs["dataset_type"] = 2
+            grp.create_dataset(
+                "displacements", data=dataset["displacements"], compression=compression
+            )
+            if "forces" in dataset:
+                grp.create_dataset(
+                    "forces", data=dataset["forces"], compression=compression
+                )
+            if "supercell_energies" in dataset:
+                grp.create_dataset(
+                    "supercell_energies",
+                    data=dataset["supercell_energies"],
+                    compression=compression,
+                )
+            if "random_seed" in dataset:
+                grp.attrs["random_seed"] = dataset["random_seed"]
+            if "cutoff_distance" in dataset:
+                grp.attrs["cutoff_distance"] = dataset["cutoff_distance"]
 
     def ph2ph(
         self,

--- a/phonopy/cui/load.py
+++ b/phonopy/cui/load.py
@@ -56,7 +56,7 @@ def load(
     phonopy_yaml: str
     | os.PathLike
     | typing.IO
-    | None = None,  # phonopy.yaml-like must be the first argument.
+    | None = None,  # phonopy.yaml-like or .hdf5 file as first argument.
     supercell_matrix: Sequence[int] | Sequence[Sequence[int]] | NDArray | None = None,
     primitive_matrix: Sequence[Sequence[float]]
     | Literal["P", "F", "I", "A", "C", "R", "auto"]
@@ -88,8 +88,8 @@ def load(
 ) -> Phonopy:
     """Create Phonopy instance from parameters and/or input files.
 
-    "phonopy_yaml"-like file is parsed unless crystal structure information is
-    given by unitcell_filename, supercell_filename, unitcell
+    "phonopy_yaml"-like file or ".hdf5" file is parsed unless crystal structure
+    information is given by unitcell_filename, supercell_filename, unitcell
     (PhonopyAtoms-like), or supercell (PhonopyAtoms-like). Even when
     "phonopy_yaml"-like file is parse, parameters except for crystal structure
     can be overwritten.
@@ -122,6 +122,9 @@ def load(
     dataset are stored in Phonopy instance, but force constants are not produced
     from dataset.
 
+    When a ".hdf5" file is given as ``phonopy_yaml``, force constants and
+    force sets stored in the HDF5 file are loaded directly.
+
     Parameters for non-analytical term correctiion (NAC)
     ----------------------------------------------------
     Optional. Means to provide NAC parameters and their priority:
@@ -133,9 +136,10 @@ def load(
     Parameters
     ----------
     phonopy_yaml : str, os.PathLike, typing.IO, optional
-        Filename of "phonopy.yaml"-like file for str or bytes, otherwise file
-        pointer-like. If this is given, the data in the file are parsed. Default
-        is None.
+        Filename of "phonopy.yaml"-like file or ".hdf5" file, or file
+        pointer-like. If this is given, the data in the file are parsed.
+        When a ".hdf5" file is given, the embedded YAML and binary data are
+        both read from it. Default is None.
     supercell_matrix : array_like, optional
         Supercell matrix multiplied to input cell basis vectors. shape=(3, ) or
         (3, 3), where the former is considered a diagonal matrix. Default is the
@@ -224,7 +228,23 @@ def load(
         Verbosity control. Default is 0.
 
     """
-    if (
+    _is_hdf5 = _is_hdf5_file(phonopy_yaml)
+
+    if _is_hdf5:
+        hdf5_data = _load_from_hdf5(
+            str(phonopy_yaml), is_compact_fc=is_compact_fc, log_level=log_level
+        )
+        cell = hdf5_data["cell"]
+        smat = supercell_matrix if supercell_matrix is not None else hdf5_data["smat"]
+        if primitive_matrix is not None:
+            pmat = primitive_matrix
+        else:
+            pmat = hdf5_data["pmat"]
+        _calculator = calculator if calculator is not None else hdf5_data["calculator"]
+        _nac_params = nac_params if nac_params is not None else hdf5_data["nac_params"]
+        _dataset = hdf5_data["dataset"]
+        _fc = hdf5_data["fc"]
+    elif (
         supercell is not None
         or supercell_filename is not None
         or unitcell is not None
@@ -350,3 +370,130 @@ def load(
         )
 
     return phonon
+
+
+def _load_from_hdf5(
+    hdf5_filename: str,
+    is_compact_fc: bool = True,
+    log_level: int = 0,
+) -> dict:
+    """Load all phonopy data from a pure HDF5 file.
+
+    Returns a dict with keys: cell, smat, pmat, calculator, nac_params,
+    dataset, fc — ready for constructing a Phonopy instance.
+
+    """
+    from phonopy.harmonic.force_constants import (
+        compact_fc_to_full_fc,
+        full_fc_to_compact_fc,
+    )
+
+    try:
+        import h5py
+    except ImportError as exc:
+        raise ModuleNotFoundError("You need to install python-h5py.") from exc
+
+    result: dict = {}
+
+    with h5py.File(hdf5_filename, "r") as f:
+        # Header
+        calculator = None
+        if "phonopy" in f and "calculator" in f["phonopy"].attrs:
+            calculator = str(f["phonopy"].attrs["calculator"])
+        result["calculator"] = calculator
+
+        # Unit cell
+        uc_grp = f["unit_cell"]
+        lattice = uc_grp["lattice"][...]
+        coordinates = uc_grp["coordinates"][...]
+        masses = uc_grp["masses"][...]
+        symbols = [s.decode() for s in uc_grp["symbols"][...]]
+        result["cell"] = PhonopyAtoms(
+            symbols=symbols,
+            cell=lattice,
+            scaled_positions=coordinates,
+            masses=masses,
+        )
+
+        # Supercell matrix
+        result["smat"] = f["supercell_matrix"][...]
+
+        # Primitive matrix
+        if "primitive_matrix" in f:
+            result["pmat"] = f["primitive_matrix"][...]
+        else:
+            result["pmat"] = None
+
+        # NAC parameters
+        nac_params = None
+        if "nac" in f:
+            nac_grp = f["nac"]
+            nac_params = {}
+            if "born" in nac_grp:
+                nac_params["born"] = nac_grp["born"][...]
+            if "dielectric" in nac_grp:
+                nac_params["dielectric"] = nac_grp["dielectric"][...]
+            if "factor" in nac_grp.attrs:
+                nac_params["factor"] = float(nac_grp.attrs["factor"])
+        result["nac_params"] = nac_params
+
+        # Force constants
+        fc = None
+        if "force_constants" in f:
+            fc = f["force_constants"][...]
+        result["fc"] = fc
+
+        # Force sets
+        dataset = None
+        if "force_sets" in f:
+            grp = f["force_sets"]
+            dtype = int(grp.attrs["dataset_type"])
+            if dtype == 1:
+                natom = int(grp.attrs["natom"])
+                numbers = grp["numbers"][...]
+                disps = grp["displacements"][...]
+                first_atoms = []
+                for i in range(len(numbers)):
+                    entry: dict = {
+                        "number": int(numbers[i]),
+                        "displacement": disps[i].tolist(),
+                    }
+                    if "forces" in grp:
+                        entry["forces"] = grp["forces"][i]
+                    if "supercell_energies" in grp:
+                        entry["supercell_energy"] = float(
+                            grp["supercell_energies"][i]
+                        )
+                    first_atoms.append(entry)
+                dataset = {"natom": natom, "first_atoms": first_atoms}
+            elif dtype == 2:
+                dataset = {
+                    "displacements": grp["displacements"][...],
+                }
+                if "forces" in grp:
+                    dataset["forces"] = grp["forces"][...]
+                if "supercell_energies" in grp:
+                    dataset["supercell_energies"] = grp["supercell_energies"][
+                        ...
+                    ]
+                if "random_seed" in grp.attrs:
+                    dataset["random_seed"] = int(grp.attrs["random_seed"])
+                if "cutoff_distance" in grp.attrs:
+                    dataset["cutoff_distance"] = float(
+                        grp.attrs["cutoff_distance"]
+                    )
+        result["dataset"] = dataset
+
+    if log_level:
+        print(f'Phonopy data were read from "{hdf5_filename}".')
+
+    return result
+
+
+def _is_hdf5_file(
+    phonopy_yaml: str | os.PathLike | typing.IO | None,
+) -> bool:
+    """Check if the given path points to an .hdf5 file."""
+    if not isinstance(phonopy_yaml, (str, os.PathLike)):
+        return False
+    return str(phonopy_yaml).endswith(".hdf5")

--- a/phonopy/file_IO.py
+++ b/phonopy/file_IO.py
@@ -432,6 +432,166 @@ def write_force_constants_to_hdf5(
             w.create_dataset("physical_unit", data=[physical_unit])
 
 
+def write_force_sets_to_hdf5(
+    dataset: dict,
+    filename: str | os.PathLike = "force_sets.hdf5",
+    compression: Literal["gzip", "lzf"] | int | None = None,
+):
+    """Write force sets (displacements and forces) in hdf5 format.
+
+    Parameters
+    ----------
+    dataset : dict
+        Displacement-force dataset. See Phonopy.dataset for the format.
+        Both type 1 and type 2 formats are supported.
+    filename : str or os.PathLike
+        Filename to be saved. Default is "force_sets.hdf5".
+    compression : str or int, optional
+        h5py's lossless compression filters (e.g., "gzip", "lzf").
+        Default is None.
+
+    """
+    try:
+        import h5py
+    except ImportError as exc:
+        raise ModuleNotFoundError("You need to install python-h5py.") from exc
+
+    with h5py.File(filename, "w") as w:
+        if "first_atoms" in dataset:
+            # Type 1 dataset
+            w.attrs["dataset_type"] = 1
+            w.attrs["natom"] = dataset["natom"]
+            n_disp = len(dataset["first_atoms"])
+            w.attrs["n_displacements"] = n_disp
+            numbers = np.array(
+                [d["number"] for d in dataset["first_atoms"]], dtype="int32"
+            )
+            displacements = np.array(
+                [d["displacement"] for d in dataset["first_atoms"]], dtype="double"
+            )
+            w.create_dataset("numbers", data=numbers, compression=compression)
+            w.create_dataset(
+                "displacements", data=displacements, compression=compression
+            )
+            if "forces" in dataset["first_atoms"][0]:
+                forces = np.array(
+                    [d["forces"] for d in dataset["first_atoms"]], dtype="double"
+                )
+                w.create_dataset("forces", data=forces, compression=compression)
+            if "supercell_energy" in dataset["first_atoms"][0]:
+                energies = np.array(
+                    [d["supercell_energy"] for d in dataset["first_atoms"]],
+                    dtype="double",
+                )
+                w.create_dataset(
+                    "supercell_energies", data=energies, compression=compression
+                )
+        elif "displacements" in dataset:
+            # Type 2 dataset
+            w.attrs["dataset_type"] = 2
+            w.create_dataset(
+                "displacements", data=dataset["displacements"], compression=compression
+            )
+            if "forces" in dataset:
+                w.create_dataset(
+                    "forces", data=dataset["forces"], compression=compression
+                )
+            if "supercell_energies" in dataset:
+                w.create_dataset(
+                    "supercell_energies",
+                    data=dataset["supercell_energies"],
+                    compression=compression,
+                )
+            if "random_seed" in dataset:
+                w.attrs["random_seed"] = dataset["random_seed"]
+            if "cutoff_distance" in dataset:
+                w.attrs["cutoff_distance"] = dataset["cutoff_distance"]
+        else:
+            raise RuntimeError("Unknown dataset format.")
+
+
+def read_force_sets_from_hdf5(
+    filename: str | os.PathLike = "force_sets.hdf5",
+) -> dict | None:
+    """Read force sets from hdf5 format.
+
+    This reads hdf5 files written by ``write_force_sets_to_hdf5`` or by
+    ``Phonopy.save(hdf5_settings=...)``. In the latter case, force sets are
+    stored under a ``"force_sets"`` group.
+
+    Parameters
+    ----------
+    filename : str or os.PathLike
+        Filename to read. Default is "force_sets.hdf5".
+
+    Returns
+    -------
+    dict or None
+        Displacement-force dataset in the format described at Phonopy.dataset.
+        Returns None if no force sets data is found.
+
+    """
+    try:
+        import h5py
+    except ImportError as exc:
+        raise ModuleNotFoundError("You need to install python-h5py.") from exc
+
+    with h5py.File(filename, "r") as f:
+        # When saved via Phonopy.save(), force sets are in a group
+        if "force_sets" in f:
+            grp = f["force_sets"]
+        elif "dataset_type" in f.attrs:
+            grp = f
+        else:
+            return None
+
+        dataset_type = grp.attrs.get("dataset_type", None)
+        if dataset_type is None:
+            return None
+
+        if dataset_type == 1:
+            dataset: dict = {"natom": int(grp.attrs["natom"]), "first_atoms": []}
+            numbers = grp["numbers"][:]
+            displacements = grp["displacements"][:]
+            forces = grp["forces"][:] if "forces" in grp else None
+            energies = (
+                grp["supercell_energies"][:] if "supercell_energies" in grp else None
+            )
+            for i in range(len(numbers)):
+                d: dict = {
+                    "number": int(numbers[i]),
+                    "displacement": np.array(displacements[i], dtype="double"),
+                }
+                if forces is not None:
+                    d["forces"] = np.array(forces[i], dtype="double", order="C")
+                if energies is not None:
+                    d["supercell_energy"] = float(energies[i])
+                dataset["first_atoms"].append(d)
+            return dataset
+
+        elif dataset_type == 2:
+            dataset = {
+                "displacements": np.array(
+                    grp["displacements"][:], dtype="double", order="C"
+                )
+            }
+            if "forces" in grp:
+                dataset["forces"] = np.array(
+                    grp["forces"][:], dtype="double", order="C"
+                )
+            if "supercell_energies" in grp:
+                dataset["supercell_energies"] = np.array(
+                    grp["supercell_energies"][:], dtype="double"
+                )
+            if "random_seed" in grp.attrs:
+                dataset["random_seed"] = int(grp.attrs["random_seed"])
+            if "cutoff_distance" in grp.attrs:
+                dataset["cutoff_distance"] = float(grp.attrs["cutoff_distance"])
+            return dataset
+
+    return None
+
+
 def parse_FORCE_CONSTANTS(
     filename: str | os.PathLike = "FORCE_CONSTANTS", p2s_map: NDArray | None = None
 ) -> NDArray:

--- a/test/api/test_api_phonopy.py
+++ b/test/api/test_api_phonopy.py
@@ -322,6 +322,122 @@ def test_Phonopy_calculator():
         assert ph.unit_conversion_factor == pytest.approx(100)
 
 
+def test_save_hdf5_force_constants(ph_nacl: Phonopy, tmp_path: Path):
+    """Test saving to .hdf5 with force_constants=True stores FC."""
+    import h5py
+
+    filename = tmp_path / "phonopy_params.hdf5"
+    ph_nacl.save(filename, settings={"force_constants": True})
+    assert filename.exists()
+    with h5py.File(filename, "r") as f:
+        assert "force_constants" in f
+        np.testing.assert_allclose(f["force_constants"][...], ph_nacl.force_constants)
+        assert "p2s_map" in f
+        np.testing.assert_array_equal(f["p2s_map"][...], ph_nacl.primitive.p2s_map)
+
+
+def test_save_hdf5_force_sets(ph_nacl: Phonopy, tmp_path: Path):
+    """Test saving to .hdf5 stores force sets."""
+    import h5py
+
+    filename = tmp_path / "phonopy_params.hdf5"
+    ph_nacl.save(filename)
+    assert filename.exists()
+    with h5py.File(filename, "r") as f:
+        assert "force_sets" in f
+        grp = f["force_sets"]
+        assert grp.attrs["dataset_type"] == 1
+        assert "displacements" in grp
+        assert "forces" in grp
+        assert "numbers" in grp
+
+
+def test_save_hdf5_both(ph_nacl: Phonopy, tmp_path: Path):
+    """Test saving to .hdf5 with both force_constants and force_sets."""
+    import h5py
+
+    filename = tmp_path / "phonopy_params.hdf5"
+    ph_nacl.save(filename, settings={"force_constants": True})
+    assert filename.exists()
+    with h5py.File(filename, "r") as f:
+        assert "force_constants" in f
+        assert "force_sets" in f
+
+
+def test_save_hdf5_structure(ph_nacl: Phonopy, tmp_path: Path):
+    """Test that HDF5 file stores structure metadata as native datasets."""
+    import h5py
+
+    filename = tmp_path / "phonopy_params.hdf5"
+    ph_nacl.save(filename)
+    with h5py.File(filename, "r") as f:
+        assert "phonopy" in f
+        assert "version" in f["phonopy"].attrs
+        assert "unit_cell" in f
+        uc = f["unit_cell"]
+        np.testing.assert_allclose(uc["lattice"][...], ph_nacl.unitcell.cell)
+        np.testing.assert_allclose(
+            uc["coordinates"][...], ph_nacl.unitcell.scaled_positions
+        )
+        np.testing.assert_allclose(uc["masses"][...], ph_nacl.unitcell.masses)
+        assert "supercell_matrix" in f
+        np.testing.assert_array_equal(
+            f["supercell_matrix"][...], ph_nacl.supercell_matrix
+        )
+
+
+def test_save_hdf5_force_sets_type2(ph_nacl: Phonopy, tmp_path: Path):
+    """Test saving type 2 dataset to .hdf5."""
+    import h5py
+
+    ph = Phonopy(
+        ph_nacl.unitcell,
+        supercell_matrix=ph_nacl.supercell_matrix,
+        primitive_matrix=ph_nacl.primitive_matrix,
+    )
+    ph.generate_displacements(number_of_snapshots=3)
+    n_supercells = len(ph.supercells_with_displacements)
+    ph.forces = np.random.default_rng(0).random((n_supercells, len(ph.supercell), 3))
+    filename = tmp_path / "phonopy_params.hdf5"
+    ph.save(filename)
+    with h5py.File(filename, "r") as f:
+        grp = f["force_sets"]
+        assert grp.attrs["dataset_type"] == 2
+        assert grp["displacements"].shape == (n_supercells, len(ph.supercell), 3)
+        assert grp["forces"].shape == (n_supercells, len(ph.supercell), 3)
+
+
+def test_load_hdf5_force_constants(ph_nacl: Phonopy, tmp_path: Path):
+    """Test loading force constants from .hdf5 file."""
+    hdf5_filename = tmp_path / "phonopy_params.hdf5"
+    ph_nacl.save(hdf5_filename, settings={"force_constants": True})
+    ph = phonopy.load(hdf5_filename, is_compact_fc=False)
+    assert ph.force_constants is not None
+    assert ph_nacl.force_constants is not None
+    np.testing.assert_allclose(ph.force_constants, ph_nacl.force_constants)
+
+
+def test_load_hdf5_force_sets(ph_nacl: Phonopy, tmp_path: Path):
+    """Test loading force sets from .hdf5 file."""
+    hdf5_filename = tmp_path / "phonopy_params.hdf5"
+    ph_nacl.save(hdf5_filename)
+    ph = phonopy.load(hdf5_filename, produce_fc=False)
+    assert ph.dataset is not None
+    assert "first_atoms" in ph.dataset
+    assert "forces" in ph.dataset["first_atoms"][0]
+
+
+def test_load_hdf5_both(ph_nacl: Phonopy, tmp_path: Path):
+    """Test loading both FC and force sets from .hdf5."""
+    hdf5_filename = tmp_path / "phonopy_params.hdf5"
+    ph_nacl.save(hdf5_filename, settings={"force_constants": True})
+    ph = phonopy.load(hdf5_filename, is_compact_fc=False)
+    assert ph.force_constants is not None
+    assert ph.dataset is not None
+    assert ph_nacl.force_constants is not None
+    np.testing.assert_allclose(ph.force_constants, ph_nacl.force_constants)
+
+
 def test_Phonopy_calculator_QE():
     """Test phonopy_load with phonopy_params.yaml for QE."""
     ph_orig = phonopy.load(


### PR DESCRIPTION
In the current code, Phonopy.save proposes a hdf5_setting but no implementation was available.

Yaml file is not super efficient for large scale saving of Phonopy objects, at least in my experience. I've added hdf5 support for that. I need to check whether is it indeed faster to load.

In my test, the loaded Phonopy is identical, although the hdf5 does not save exactly the same information. Some information in yaml are not used when loaded (symprec / symmetry_tolerance for instance).