### PR TITLE
Update ylabel in plot_gibbs_temperature method

### DIFF
--- a/phonopy/qha/core.py
+++ b/phonopy/qha/core.py
@@ -712,7 +712,7 @@ class QHA:
     def plot_gibbs_temperature(
         self,
         xlabel: str = "Temperature (K)",
-        ylabel: str = "Gibbs free energy",
+        ylabel: str = "Gibbs free energy (eV)",
     ) -> Any:
         """Return pyplot Gibbs free energy vs temperature."""
         import matplotlib.pyplot as plt


### PR DESCRIPTION
I have added eV units to the y-axis of `plot_gibbs_temperature()`. Partially (but not completely) addresses #859.

Please let me know if this is incorrect.