### PR TITLE
docs: include units in QHA plot y-axis labels

### DIFF
--- a/phonopy/api_qha.py
+++ b/phonopy/api_qha.py
@@ -154,7 +154,7 @@ class PhonopyQHA:
         Returns
         -------
         list
-            Thermal expansion coefficients at temperatues.
+            Thermal expansion coefficients at temperatues in K^-1.
             shape=(temperatures, )
 
         """
@@ -167,7 +167,7 @@ class PhonopyQHA:
         Returns
         -------
         ndarray
-            Helmholtz free energies calculated at temperatures and volumes.
+            Helmholtz free energies calculated at temperatures and volumes in eV.
             shape=(temperatures, volumes)
 
         """
@@ -180,7 +180,7 @@ class PhonopyQHA:
         Returns
         -------
         ndarray
-            Equilibrium volumes at temperatures
+            Equilibrium volumes at temperatures in Angstrom^3.
             shape=(temperatures,), dtype=float
 
         """
@@ -193,7 +193,7 @@ class PhonopyQHA:
         Returns
         -------
         ndarray
-            Gibbs free energies at temperatures.
+            Gibbs free energies at temperatures in eV.
             shape=(temperatures, ), dtype=float
 
         """
@@ -206,7 +206,7 @@ class PhonopyQHA:
         Returns
         -------
         ndarray
-            Bulk modulus at constant pressure and temperatures
+            Bulk modulus at constant pressure and temperatures in GPa.
             shape=(temperatures, ), dtype=float
 
         """
@@ -378,7 +378,7 @@ class PhonopyQHA:
     def plot_gibbs_temperature(
         self,
         xlabel: str = "Temperature (K)",
-        ylabel: str = "Gibbs free energy",
+        ylabel: str = "Gibbs free energy (eV)",
     ) -> Any:
         """Return pyplot of Gibbs free energy vs temperature."""
         return self._qha.plot_gibbs_temperature(xlabel=xlabel, ylabel=ylabel)
@@ -392,7 +392,7 @@ class PhonopyQHA:
     def plot_bulk_modulus_temperature(
         self,
         xlabel: str = "Temperature (K)",
-        ylabel: str = "Bulk modulus",
+        ylabel: str = "Bulk modulus (GPa)",
     ) -> Any:
         """Return pyplot of bulk modulus vs temperature."""
         return self._qha.plot_bulk_modulus_temperature(xlabel=xlabel, ylabel=ylabel)

--- a/test/qha/test_QHA.py
+++ b/test/qha/test_QHA.py
@@ -443,6 +443,24 @@ def test_write_gruneisen_temperature(qha_si: PhonopyQHA, tmp_path: Path) -> None
     np.testing.assert_allclose(data[:, 1], qha_si.gruneisen_temperature, atol=1e-10)
 
 
+def test_qha_plot_units(qha_si: PhonopyQHA) -> None:
+    """y-axis labels of QHA plots carry units, and unit-annotated docstrings."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    plt = qha_si.plot_gibbs_temperature()
+    assert "(eV)" in plt.gca().get_ylabel()
+    plt.close("all")
+
+    plt = qha_si.plot_bulk_modulus_temperature()
+    assert "(GPa)" in plt.gca().get_ylabel()
+    plt.close("all")
+
+    assert "eV" in PhonopyQHA.gibbs_temperature.__doc__
+    assert "GPa" in PhonopyQHA.bulk_modulus_temperature.__doc__
+
+
 def _print_values(values: NDArray[np.double]) -> None:
     print("%.7f," % values[0])
     for line in np.reshape(values[1:], (-1, 5)):


### PR DESCRIPTION
## Summary

Annotate the QHA plot y-axis labels with their physical units so the default plots are self-describing, and add the missing units to the corresponding `PhonopyQHA` property docstrings.

## Why this matters

Issue #859 asks for clearer unit annotations across phonopy, calling out two concrete QHA pain points: `qha.plot_gibbs_temperature()` renders a y-axis with no units, and the property attribute docstrings omit the units of the returned arrays. Because thermal-property energies appear in different units across phonopy's I/O (eV vs kJ/mol), an unlabeled axis or docstring makes unit-mismatch mistakes easy.

The public `PhonopyQHA.plot_gibbs_temperature` / `plot_bulk_modulus_temperature` wrappers passed unit-less `ylabel` defaults (`"Gibbs free energy"`, `"Bulk modulus"`) that overrode the unit-bearing defaults already present in `phonopy/qha/core.py`. This change makes the wrappers consistent with `core.py`.

## Changes

- `phonopy/api_qha.py`
  - `plot_gibbs_temperature`: default `ylabel` is now `"Gibbs free energy (eV)"`.
  - `plot_bulk_modulus_temperature`: default `ylabel` is now `"Bulk modulus (GPa)"`.
  - Added units to the returned-array docstrings of `gibbs_temperature` (eV), `bulk_modulus_temperature` (GPa), `volume_temperature` (Angstrom^3), `thermal_expansion` (K^-1), and `helmholtz_volume` (eV).
- `test/qha/test_QHA.py`
  - Added `test_qha_plot_units`, which builds the existing `qha_si` fixture, asserts the Gibbs and bulk-modulus plot y-labels carry `(eV)` / `(GPa)`, and guards the unit annotations in the property docstrings.

This is a labels/docstrings-only change; no numeric behavior is altered.

## Testing

`pytest test/qha/test_QHA.py` (Agg backend) -> 11 passed, including the new `test_qha_plot_units` and all existing numeric QHA regression assertions, confirming the change is label/docstring-only.

This addresses the QHA portion of the issue; the broader sweep across all plots and properties is left for follow-up.

Refs #859
