### PR TITLE
docs: add physical units to thermal properties dict docstring

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -2514,13 +2514,17 @@ class Phonopy:
         'free_energy', 'entropy', and 'heat_capacity'.
         Each value of corresponding key is as follows:
 
-        temperatures: ndarray
+        temperatures : ndarray
+            Temperatures in K.
             shape=(temperatures, ), dtype='double'
         free_energy : ndarray
+            Helmholtz free energies in kJ/mol.
             shape=(temperatures, ), dtype='double'
         entropy : ndarray
+            Entropies in J/K/mol.
             shape=(temperatures, ), dtype='double'
         heat_capacity : ndarray
+            Heat capacities in J/K/mol.
             shape=(temperatures, ), dtype='double'
 
         .. deprecated::

--- a/test/api/test_api_phonopy.py
+++ b/test/api/test_api_phonopy.py
@@ -1,6 +1,7 @@
 """Tests of Phonopy API."""
 
 import copy
+import inspect
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +10,7 @@ import pytest
 import phonopy
 from phonopy import Phonopy
 from phonopy.interface.pypolymlp import PypolymlpParams
+from phonopy.phonon.thermal_properties import ThermalProperties
 from phonopy.structure.cells import isclose
 from phonopy.structure.dataset import get_displacements_and_forces
 
@@ -357,6 +359,30 @@ def test_run_methods_return_result_objects(ph_nacl: Phonopy):
         [[0.5, 0.5, 0.5]], 300, scattering_lengths={"Na": 3.63, "Cl": 9.5770}
     )
     assert dsf is ph.dynamic_structure_factor
+
+
+def test_thermal_properties_dict_docstring_units() -> None:
+    """Thermal property dict accessor docstring carries physical units."""
+    raw_doc = Phonopy.get_thermal_properties_dict.__doc__
+    assert raw_doc is not None
+    doc = inspect.cleandoc(raw_doc)
+    doc_lines = doc.splitlines()
+
+    expected_descriptions = {
+        "temperatures": "Temperatures in K.",
+        "free_energy": "Helmholtz free energies in kJ/mol.",
+        "entropy": "Entropies in J/K/mol.",
+        "heat_capacity": "Heat capacities in J/K/mol.",
+    }
+    for attr, description in expected_descriptions.items():
+        index = doc_lines.index(f"{attr} : ndarray")
+        assert doc_lines[index + 1].strip() == description
+
+    for attr in ("free_energy", "entropy", "heat_capacity"):
+        source_doc = getattr(ThermalProperties, attr).__doc__
+        assert source_doc is not None
+        unit = expected_descriptions[attr].rsplit(" in ", maxsplit=1)[1].rstrip(".")
+        assert unit in source_doc
 
 
 def test_Phonopy_calculator():


### PR DESCRIPTION
## Summary

`Phonopy.get_thermal_properties_dict` documented each returned array only by shape and dtype, not by physical unit, so a caller reading the docstring could not tell whether `free_energy` was in eV, kJ/mol, or something else. This adds the physical units to the docstring for the four returned quantities, matching the units the underlying `ThermalProperties` arrays are actually computed in.

## Why this matters

Issue #859 asks for the thermal-properties units to be discoverable from the API. Without them, users have to read the source of `ThermalProperties` to find that temperatures are in K and the energy/entropy/heat-capacity quantities are per-mole. Stating the units where the values are returned removes that round-trip and the risk of unit errors in downstream analysis.

The units added are taken from the `ThermalProperties` source, not invented: temperatures in K, Helmholtz free energy in kJ/mol, entropy in J/K/mol, and heat capacity in J/K/mol.

## Changes

`phonopy/api_phonopy.py` adds a one-line unit description under each of `temperatures`, `free_energy`, `entropy`, and `heat_capacity` in the `get_thermal_properties_dict` docstring. No behavior changes.

## Testing

Added `test_thermal_properties_dict_docstring_units` in `test/api/test_api_phonopy.py`. It asserts the docstring carries the expected unit text and, to keep the documentation honest, cross-checks each unit against the `ThermalProperties` source docstring so the doc cannot drift from the actual units. `pytest test/api/test_api_phonopy.py` passes (17 passed, 2 skipped).

Refs #859
