### PR TITLE
Propagate frequency conversion factor to dynamic structure factor

### DIFF
--- a/phonopy/api_phonopy.py
+++ b/phonopy/api_phonopy.py
@@ -3336,6 +3336,7 @@ class Phonopy:
             scattering_lengths=scattering_lengths,
             freq_min=freq_min,
             freq_max=freq_max,
+            factor=self._unit_conversion_factor,
         )
         return self._dynamic_structure_factor
 

--- a/phonopy/spectrum/dynamic_structure_factor.py
+++ b/phonopy/spectrum/dynamic_structure_factor.py
@@ -112,6 +112,7 @@ class DynamicStructureFactor:
         scattering_lengths: dict[str, float] | None = None,
         freq_min: float | None = None,
         freq_max: float | None = None,
+        factor: float | None = None,
     ) -> None:
         """Init method.
 
@@ -149,6 +150,9 @@ class DynamicStructureFactor:
         freq_max: float
             Maximum phonon frequency to determine whether include or not. Only
             for Debye-Waller factor.
+        factor: float, optional
+            Unit conversion factor for phonon frequencies. Default is
+            DefaultToTHz of the physical units.
 
         """
         self._mesh_phonon = mesh_phonon
@@ -177,7 +181,7 @@ class DynamicStructureFactor:
         )
         self._frequencies: NDArray[np.double]
         self._eigvecs: NDArray[np.cdouble]
-        self._set_phonon()
+        self._set_phonon(factor)
 
         self._q_count = 0
         self._unit_conversion_factor = 1.0 / (
@@ -260,9 +264,12 @@ class DynamicStructureFactor:
                 S[i] = abs(F) ** 2 * (n + 1)
         return S * self._unit_conversion_factor
 
-    def _set_phonon(self) -> None:
+    def _set_phonon(self, factor: float | None) -> None:
         qpoints_phonon = QpointsPhonon(
-            self._qpoints_1bz, self._dynamical_matrix, with_eigenvectors=True
+            self._qpoints_1bz,
+            self._dynamical_matrix,
+            with_eigenvectors=True,
+            factor=factor,
         )
         self._frequencies = qpoints_phonon.frequencies
         assert qpoints_phonon.eigenvectors is not None

--- a/test/spectrum/test_dynamic_structure_factor.py
+++ b/test/spectrum/test_dynamic_structure_factor.py
@@ -9,6 +9,7 @@ from numpy.typing import ArrayLike
 
 from phonopy.api_phonopy import Phonopy
 from phonopy.spectrum.dynamic_structure_factor import atomic_form_factor_WK1995
+from phonopy.structure.atoms import PhonopyAtoms
 
 # D. Waasmaier and A. Kirfel, Acta Cryst. A51, 416 (1995)
 # f(Q) = \sum_i a_i \exp((-b_i Q^2) + c
@@ -168,6 +169,28 @@ def test_IXS_G_to_L_NaCl(ph_nacl: Phonopy):
         degeneracies,
         verbose=False,
     )
+
+
+def test_dsf_frequencies_use_unit_conversion_factor():
+    """DSF and band frequencies use the same configured factor."""
+    phonon = Phonopy(
+        PhonopyAtoms(
+            symbols=["Si"],
+            cell=np.eye(3),
+            scaled_positions=[[0, 0, 0]],
+        ),
+        supercell_matrix=np.eye(3, dtype=int),
+        primitive_matrix=np.eye(3),
+    )
+    phonon.force_constants = np.diag([1.0, 4.0, 9.0]).reshape(1, 1, 3, 3)
+    phonon.unit_conversion_factor *= 2
+
+    qpoint = [0.25, 0.0, 0.0]
+    phonon.run_mesh([1, 1, 1], is_mesh_symmetry=False, with_eigenvectors=True)
+    dsf = phonon.init_dynamic_structure_factor([qpoint], 300)
+    band = phonon.run_band_structure([[qpoint]])
+
+    np.testing.assert_allclose(dsf.frequencies, band.frequencies[0])
 
 
 def _test_IXS_G_to_L(


### PR DESCRIPTION
## Summary

- propagate `Phonopy.unit_conversion_factor` to the q-point calculation used by `DynamicStructureFactor`
- add a self-contained one-atom regression test comparing DSF and band frequencies with a custom conversion factor

## Root cause

Band, mesh, and q-point calculations receive the configured frequency conversion factor, but `DynamicStructureFactor` created its internal `QpointsPhonon` without that factor. It therefore fell back to the default conversion and produced inconsistent frequencies when the configured factor was overridden.

The new optional constructor argument defaults to `None`, preserving the previous behavior for direct `DynamicStructureFactor` callers.

## Validation

- regression test on current `main` before the fix: 1 expected failure; DSF frequencies were exactly 0.5 of band frequencies with a 2x factor
- focused regression after the fix: 1 passed
- adjacent DSF/q-point/band/spectrum tests: 123 passed
- full test tree: 1191 passed, 34 skipped; warnings are pre-existing and unrelated
- Ruff, applicable pre-commit hooks, and `git diff --check`: passed

## AI assistance disclosure

OpenAI Codex was used to diagnose, implement, and test this change.

Closes #901
