### PR TITLE
Restore nac_factor 1 for Elk, TURBOMOLE and Fleur

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,6 +11,11 @@
   reported in. `sscha_free_energies.yaml` records the supercell energy beside
   the other settings, and each iteration now reports `potential_energy` and
   `harmonic_potential_energy`, the two terms `anharmonic` is the difference of.
+- Bug fix: the non-analytical term correction factor for Elk, TURBOMOLE and
+  Fleur is 1 again, the value {ref}`documented
+  <nac_default_value_interfaces>` for them. It became 14.399652 in v3.4.0,
+  when those three interfaces were folded into one branch with DFTB+, which
+  shifted LO frequencies for anyone running NAC through them.
 - Behavior change: `phonopy-vasp-efe` integrates the electronic free energy by
   the linear tetrahedron method over the mesh each `vasprun.xml` describes,
   where it used to sum Fermi-Dirac occupations over the irreducible k-points.

--- a/phonopy/physical_units.py
+++ b/phonopy/physical_units.py
@@ -394,9 +394,17 @@ def get_calculator_physical_units(
             / (2 * pi)
             / 1e12
         )  # [THz] 154.10794
+        # Cells stay in bohr and force constants in hartree/bohr^2, so
+        # e^2/(4*pi*eps0) is 1 hartree*bohr here. DFTB+ is left on the
+        # eV*angstrom value it has used since 2021.
+        nac_factor = (
+            physical_units.Hartree * physical_units.Bohr
+            if interface_mode in ("dftbp", "exciting")
+            else 1.0
+        )
         units = CalculatorPhysicalUnits(
             factor=ElkToTHz,
-            nac_factor=physical_units.Hartree * physical_units.Bohr,
+            nac_factor=nac_factor,
             distance_to_A=physical_units.Bohr,
             force_to_eVperA=physical_units.Hartree / physical_units.Bohr,
             energy_to_eV=physical_units.Hartree,

--- a/test/test_physical_units.py
+++ b/test/test_physical_units.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Tests for phonopy.physical_units."""
+
+from __future__ import annotations
+
+import pytest
+
+from phonopy.physical_units import get_calculator_physical_units
+
+# e^2 / (4 pi eps0) = 14.3996454 eV.Angstrom (CODATA 2022 elementary charge and
+# vacuum electric permittivity), which is 1 hartree*bohr, 2 Ry*bohr and
+# 2000 mRy*bohr.
+E2_OVER_4PIEPS0_EV_ANGSTROM = 14.3996454
+
+# nac_factor is used in dynamical_matrix.py as
+#   nac_factor * 4*pi / volume * (q.Z)(q.Z) / (q.eps.q)
+# and added to the force constants, and the cell keeps the calculator's own
+# length unit, so nac_factor is e^2/(4 pi eps0) written in
+# force_constants_unit * length_unit^3.  These are the values documented in
+# doc/interfaces.md.
+EXPECTED_NAC_FACTOR = {
+    "vasp": E2_OVER_4PIEPS0_EV_ANGSTROM,  # eV/angstrom^2, angstrom
+    "qe": 2.0,  # Ry/au^2, au
+    "wien2k": 2000.0,  # mRy/au^2, au
+    "elk": 1.0,  # hartree/au^2, au
+    "turbomole": 1.0,  # hartree/au^2, au
+    "fleur": 1.0,  # hartree/au^2, au
+    "octopus": 1.0,  # hartree/au^2, au
+}
+
+
+@pytest.mark.parametrize("interface_mode", EXPECTED_NAC_FACTOR)
+def test_nac_factor(interface_mode: str):
+    """Test nac_factor is e^2/(4 pi eps0) in the calculator's own units."""
+    units = get_calculator_physical_units(interface_mode)
+    assert units.nac_factor == pytest.approx(
+        EXPECTED_NAC_FACTOR[interface_mode], rel=1e-5
+    )
+
+
+def test_nac_factor_dftbp_unchanged():
+    """Test DFTB+ keeps the value it has had since 2021.
+
+    This pins current behaviour rather than deriving it; doc/interfaces.md
+    documents 14.399652 for DFTB+.
+    """
+    units = get_calculator_physical_units("dftbp")
+    assert units.nac_factor == pytest.approx(E2_OVER_4PIEPS0_EV_ANGSTROM, rel=1e-5)
+
+
+def test_nac_factor_agrees_across_identical_unit_systems():
+    """Test branches declaring the same units agree on nac_factor."""
+    reference = get_calculator_physical_units("octopus")
+    for interface_mode in ("elk", "turbomole", "fleur"):
+        units = get_calculator_physical_units(interface_mode)
+        assert units.force_constants_unit == reference.force_constants_unit
+        assert units.length_unit == reference.length_unit
+        assert units.nac_factor == reference.nac_factor


### PR DESCRIPTION
`get_calculator_physical_units` returns `nac_factor = 14.399652` for Elk, TURBOMOLE and Fleur. `doc/interfaces.md` documents `1` for all three, and the code returned 1.0 until v3.4.0: commit `30450161` ("Added energy_to_eV to CalculatorPhysicalUnits") turned `elif interface_mode == "elk":` into `elif interface_mode in ("elk", "dftbp", "turbomole", "fleur"):` and kept DFTB+'s value. Present in every release from v3.4.0 to v4.3.0.

`nac_factor` is e²/(4πε₀) written in `force_constants_unit × length_unit³`, because the cell keeps the calculator's own length unit (`read_elk` returns bohr). For `hartree/au^2` + `au` that is 1 hartree·bohr = 1.0 — which is exactly what the `octopus` branch, with an identical `force_constants_unit` and `length_unit`, already uses. On master the two disagree:

```
elk        nac=   14.399652  fc_unit=hartree/au^2  len=au
octopus    nac=    1.000000  fc_unit=hartree/au^2  len=au
```

What it costs a user, measured on the bundled `test/phonopy_params_NaCl-1.00.yaml.xz` at q=(0.01,0,0) with `nac_q_direction=[1,0,0]` — the same crystal expressed once in VASP units and once in atomic units (cell ÷ Bohr, force constants × Bohr²/Hartree):

```
VASP units, nac 14.399652   [0.08483 0.08483 0.13633 4.65507 4.65507  7.45011] THz
atomic units, nac 14.399652 [0.10448 0.10448 0.10558 4.63714 4.63714 22.54552]   max|df| 15.10 THz
atomic units, nac 1.0       [0.08483 0.08483 0.13633 4.65507 4.65507  7.45011]   max|df|  0.00 THz
```

The LO mode goes 7.45 → 22.55 THz. The `nac 1.0` leg reproducing the VASP leg exactly is what validates the harness.

Two things I did **not** change:

- **DFTB+** reads forces in hartree/bohr and cells in bohr, so by the same argument it wants 1.0 too — but it has had 14.399652 since 2021 and `doc/interfaces.md` says so, which is a documented decision rather than a slip. Left as is and pinned by a test.
- **exciting** was added into the same branch after the regression, so it inherited 14.399652 and is not in the doc table. It shares Elk's unit declarations, so it probably wants 1.0 as well; say the word and I will include it.

Ran `pytest test` on master and on the branch in the same env: 1424 passed / 50 skipped → 1433 passed / 50 skipped, no failures either leg. `ruff check` and `ruff format --check` clean at the pinned 0.16.5. Mutants: reverting the constant fails 4 of the new tests; setting the whole group to 1.0 (sweeping DFTB+ along) fails the DFTB+ pin; fixing only Elk fails the TURBOMOLE and Fleur cases.

Not tested: no Elk, TURBOMOLE or Fleur run of my own — the demonstration above changes units on a VASP dataset rather than parsing those codes' output, and the C extension is not built here (pure-Python path only).

AI assistance: this change was drafted with Claude Opus 5 (`claude-opus-5`).
