### PR TITLE
Restore aqha

### DIFF
--- a/doc/anisotropic-qha.md
+++ b/doc/anisotropic-qha.md
@@ -942,11 +942,10 @@ of every atom.
 Four steps, once the dataset of step 3 exists. The harmonic force constants
 it carries are what set the widths of the draw.
 
-1. Pick temperatures covering the range you want, and add one point above
-   that range. An MLP tends to be poor outside the range it was trained on.
-   Script 5 below trains at 0, 100, 250 and 400 K. Script 7 then analyses up
-   to 400 K, and the finite difference consumes that top point, so the
-   reported results stop at 390 K and stay inside the trained range.
+1. Pick temperatures covering the temperatures script 7 will run. An MLP
+   tends to be poor outside the range it was trained on. Script 5 below
+   trains at 0, 100, 250 and 400 K, and script 7 runs up to 400 K, so every
+   SSCHA run stays inside the trained range.
 2. Generate the displacements with the script below. It reads the harmonic
    force constants from the dataset of step 3, and uses one draw of standard
    normals at every grid point; see {ref}`anisotropic-qha-normals`.
@@ -1289,25 +1288,42 @@ harmonic expression of "The free energy" above.
 
 The `aniso_qha_dataset.hdf5` of step 3 is used as it is. Script 7, listed in
 {ref}`the appendix <anisotropic-qha-sweep-script>` at the end of this page,
-makes one SSCHA run at every grid point and every temperature. Save it as
-`script7.py`. Each run starts from the harmonic force constants the dataset
-carries. With no options it runs the whole grid and writes `sscha.hdf5`, and
-`-a` turns that into the `fph.hdf5` the analysis reads:
+computes the free energy at one (temperature, grid point) pair. Save it as
+`script7.py`. The axial thermal expansions are computed from the free energies
+of all the pairs.
+
+`TEMPERATURES` **must be decided before the first SSCHA run**. The script has
+`TEMPERATURES = np.arange(0, 410, 10.0)` at the top, 0 to 400 K in 10 K steps.
+These 41 temperatures over the 5 x 5 lattice grid of step 1 require 1,025
+calls of `script7.py`.
+
+{math}`a(T)` and {math}`c(T)` are obtained by minimizing the free-energy
+surface at each temperature. The axial expansions then come from an Einstein
+fit of {math}`a(T)` and {math}`c(T)` over the whole temperature range,
+described in {ref}`running the analysis
+<anisotropic-qha-sscha-analysis>`. A temperature at the end of that range is
+not interpolated, so it is recommended to take the highest of `TEMPERATURES`
+above the highest temperature to report.
+
+Script 7 starts each run from the harmonic force constants the dataset carries
+and writes the run to its own file. `-a` gathers those files into the
+`fph.hdf5` the analysis reads:
 
 ```bash
-% python script7.py -v
+% python script7.py -g 13 -t 250 -v
 % python script7.py -a
 ```
 
-`-v` lists the iterations of every run. The transient is chosen from that
-list, so the first sweep is worth running with it; `-vv` adds the
-force-constant fit.
+{ref}`Gathering the runs <anisotropic-qha-gather>` below covers how the calls
+are spread over jobs and how `-a` puts them back together. It is worth making
+one run first with `-v`, which lists its iterations. The transient is chosen
+from that listing, and `-vv` adds the force-constant fit.
 
-Sampling and averaging are separate steps whichever way the runs are made.
-The averaging is where the transient is chosen, and doing it apart means
-choosing again costs a second of arithmetic rather than the whole sweep.
+Sampling and averaging are separate steps. The averaging is where the
+transient is chosen, and doing it apart means choosing again costs a second of
+arithmetic rather than the whole sweep.
 
-The constants at the top set the run and what its averaging leaves out.
+The other constants at the top set the run and what its averaging leaves out.
 
 `SNAPSHOTS` is how many supercells each SSCHA iteration draws, 2000 in the
 script against phonopy's own 1000. Each one is an MLP evaluation, which makes
@@ -1379,6 +1395,50 @@ from a sample as well, and that variation appears as scatter of the kept
 iterations about their mean, which is the column `-v` prints. Iterations that
 scatter by about their own {math}`e_i` say that {math}`e` is the whole of it.
 
+(anisotropic-qha-gather)=
+### Gathering the runs into `fph.hdf5`
+
+One SSCHA run is minutes with the lightest descriptor and longer with a heavy
+one, and the 1,025 of them are independent of each other, so they can be split
+over processes, nodes or jobs however is convenient. A run's randomness comes
+from `SEED` and the iteration number alone, so it gives the same numbers
+whenever and wherever it is made.
+
+The grid point is numbered from 1, and the temperature is in K, taken to the
+nearest of `TEMPERATURES`. A submitting script can therefore carry its own
+temperatures, since one that is off by rounding still lands on the temperature
+the gather expects.
+
+```bash
+% python script7.py -g 13 -t 250
+(013, 250.0)
+Wrote sscha-g013-t250K.hdf5
+```
+
+Sampling writes one `sscha-g*K.hdf5` per run. Averaging writes `fph.hdf5`,
+which is the file the analysis reads.
+
+The two are different types, not two spellings of one. A `sscha-g*K.hdf5`
+file holds an `SSCHARun`, every iteration and no average, and is what another
+transient is taken from. `fph.hdf5` holds `SSCHAFreeEnergies`, the averages
+and the transient they were taken with. Handing the analysis a run stops with
+a message about its type, rather than averaging it over iterations nobody
+chose.
+
+`-a` gathers the `sscha-g*K.hdf5` files into `fph.hdf5`:
+
+```bash
+% python script7.py -a
+Wrote fph.hdf5 from 1025 file(s)
+```
+
+Each file is placed by the lattice lengths and the temperature it carries
+rather than by its name, so the order they are gathered in does not matter. A
+missing value stops the write and is named, since the analysis would otherwise
+read a gap as a zero. A grid point and temperature that two files cover stops
+the write as well.
+
+
 ### Choosing the transient
 
 `--transient` sets how many iterations are left out of the averages. The
@@ -1413,65 +1473,18 @@ until every kept iteration is within a few units. Check the highest
 temperature as well as the lowest, since the distance between the harmonic and
 the self-consistent force constants grows with temperature.
 
-### Splitting the runs across jobs
-
-One SSCHA run is minutes with the lightest descriptor and longer with a heavy
-one. Multiplied by the grid points and the temperatures, the step comes to
-hours or days. Spreading the runs over processes, nodes or jobs is therefore
-worth the trouble.
-
-Nothing constrains how they are spread. A run's randomness comes from `SEED`
-and the iteration number alone, so a run gives the same numbers wherever it
-sits in the two loops and whenever it is made. Either loop can be sliced, or
-both.
-
-`-g` and `-t` run one grid point at one temperature, and write that one value
-to its own file. The two go together, and one without the other stops the
-script. The grid point is numbered from 1, and the temperature is in K, taken
-to the nearest of `TEMPERATURES`:
-
-```bash
-% python script7.py -g 13 -t 250
-(013, 250.0)
-Wrote sscha-g013-t250K.hdf5
-```
-
-Sampling writes `sscha*.hdf5`, one file per run here and one for the whole
-grid when the grid is run in one process. Averaging writes `fph.hdf5`, which
-is the file the analysis reads.
-
-The two are different types, not two spellings of one. A `sscha*.hdf5` file
-holds `SSCHAIterations`, every iteration and no average, and is what another
-transient is taken from. `fph.hdf5` holds `SSCHAFreeEnergies`, the averages
-and the transient they were taken with. Handing the analysis a `sscha*.hdf5`
-file stops with a message about its type, rather than averaging it over
-iterations nobody chose.
-
-One such call is one job. `-a` gathers the `sscha*.hdf5` files into
-`fph.hdf5`:
-
-```bash
-% python script7.py -a
-Wrote fph.hdf5 from 1025 file(s)
-```
-
-Each file is placed by the lattice lengths and the temperature it carries
-rather than by its name, so the order they are gathered in does not matter. A
-missing value stops the write and is named, since the analysis would otherwise
-read a gap as a zero.
-
-`-a` averages the iterations each file carries rather than reading the
-averages the runs wrote, so `--transient` applies to the whole grid at once:
+The run files hold every iteration and no average. `-a` computes the averages,
+leaving out the first `--transient` iterations of each run:
 
 ```bash
 % python script7.py -a --transient 2
 ```
 
-That costs no sampling, so gathering the same files again with another value
-is how one transient is compared with another. The runs gathered into one file
-have to have made the same number of iterations, since one array cannot hold
-runs of two lengths, and one grid point and temperature covered by two files
-stops the write.
+Trying `--transient 3` will simply overwrite the existing `fph.hdf5`.
+
+The runs gathered into one file must all have made the same number of
+iterations. Averaging over different numbers would weight the grid unevenly,
+so the gather stops and names the numbers it found.
 
 
 ### Supplying the free energies to the analysis
@@ -1530,6 +1543,7 @@ harmonic force constants. Script 7 therefore cannot use such a dataset, having
 nothing to start the SSCHA runs
 from.
 
+(anisotropic-qha-sscha-analysis)=
 ### Running the analysis
 
 The file is given to the analysis with `--phonon-free-energies`:
@@ -1613,10 +1627,9 @@ returning a curve of the wrong shape.
 (anisotropic-qha-sweep-script)=
 ## Appendix: the SSCHA sweep script
 
-The script {ref}`the SSCHA step <anisotropic-qha-sscha>` calls. With no options it
-runs every grid point and every temperature and writes `sscha.hdf5`. `-g` and
-`-t` run one of them and write it to its own file, which is how the sweep is
-spread over jobs. `-a` gathers what the runs wrote into `fph.hdf5`.
+The script {ref}`the SSCHA step <anisotropic-qha-sscha>` calls. `-g` and `-t`
+run one grid point at one temperature and write it to its own file, and `-a`
+gathers what the runs wrote into `fph.hdf5`.
 `--transient` says how many iterations at the start of each run to leave out
 of the averages, and applies to a gather as well as to a run. `-v` lists each
 iteration with its departure from the mean of the kept ones, which is what
@@ -1632,17 +1645,15 @@ import numpy as np
 from phonopy.interface.mlp import PhonopyMLP
 from phonopy.qha.anisotropic_dataset import read_aniso_qha_dataset
 from phonopy.qha.free_energy_io import (
-    SSCHAFreeEnergies,
-    SSCHAIterations,
-    read_sscha_iterations_hdf5,
+    assemble_sscha_free_energies,
     write_free_energies_hdf5,
-    write_sscha_iterations_hdf5,
 )
 from phonopy.sscha.core import MLPSSCHA
+from phonopy.sscha.run import read_sscha_run_hdf5, write_sscha_run_hdf5
 
 DATASET = "aniso_qha_dataset.hdf5"
 MLP = "train/grid-{:03d}/polymlp.yaml"  # grid point, numbered from 1
-TEMPERATURES = np.arange(0, 410, 10.0)  # one extra point for finite diff
+TEMPERATURES = np.arange(0, 410, 10.0)  # 0 to 400 K in 10 K steps
 SNAPSHOTS = 2000
 ITERATIONS = 16
 MESH = 200.0
@@ -1650,158 +1661,9 @@ SEED = 1000
 DEFAULT_TRANSIENT = 1
 
 
-def report_iterations(history, transient):
-    """List the iterations, and how far each sits from the mean of the kept ones.
-
-    The departure is measured in the iteration's own error, so it reads the
-    same whatever the system: an iteration standing well outside the scatter
-    of the others has not reached self-consistency and belongs to the
-    transient.
-
-    """
-    kept = history[transient:]
-    mean = np.mean([h.free_energy for h in kept])
-    print("  iter       F [meV]   error [meV]   (F - mean)/error", flush=True)
-    for position, h in enumerate(history):
-        mark = "*" if position < transient else " "
-        print(
-            f"  {h.iteration:4d}{mark} {h.free_energy * 1e3:12.4f} "
-            f"{h.free_energy_error * 1e3:13.4f} "
-            f"{(h.free_energy - mean) / h.free_energy_error:+18.1f}",
-            flush=True,
-        )
-    worst = max(kept, key=lambda h: abs(h.free_energy - mean) / h.free_energy_error)
-    sigma = abs(worst.free_energy - mean) / worst.free_energy_error
-    print(
-        f"  * left out as the transient. Of the kept iterations the furthest "
-        f"from the mean is {worst.iteration}, at {sigma:.1f} sigma.",
-        flush=True,
-    )
-    print(
-        "  A kept iteration far outside the scatter of the rest is still in "
-        "the transient: raise --transient and look again.",
-        flush=True,
-    )
-
-
-def average(iterations, transient):
-    """Return the mean over the iterations after the transient."""
-    return iterations[..., transient:].mean(axis=-1)
-
-
-def combine(errors, transient):
-    """Return the error of that mean, over the iterations after the transient.
-
-    The iterations are independent draws, so their errors add in quadrature
-    rather than being averaged.
-
-    """
-    kept = errors[..., transient:]
-    return np.sqrt(np.square(kept).sum(axis=-1)) / kept.shape[-1]
-
-
-def write_sampled(temperatures, lattice_lengths, terms, reference, filename):
-    """Write what the runs sampled, one value per iteration."""
-    free_energies, errors, potential, harmonic_potential = terms
-    write_sscha_iterations_hdf5(
-        SSCHAIterations(
-            temperatures,
-            free_energies,
-            errors,
-            potential,
-            harmonic_potential,
-            reference,
-            lattice_lengths=lattice_lengths,
-        ),
-        filename,
-    )
-
-
-def sscha_free_energy(
-    ph,
-    mlp,
-    temperature,
-    force_constants=None,
-    transient=DEFAULT_TRANSIENT,
-    log_level=0,
+def run_sscha(
+    dataset, grid_point, temperature, transient=DEFAULT_TRANSIENT, log_level=0
 ):
-    """Return the iterations of one SSCHA run, in eV per primitive cell.
-
-    The free energy, its error, and the two ensemble averages the anharmonic
-    correction is the difference of, one value per iteration; then the energy
-    of the supercell without displacements the whole is measured from. That
-    last one is returned twice: as the static energy to put back, and as the
-    origin the free energy is measured from. They are the same here and need
-    not be.
-
-    Every iteration is returned and no averaging is done here, so that
-    another transient can be taken later without sampling again. ``transient``
-    is used for the log alone.
-
-    ``force_constants`` starts the iteration from a set of one's own. Without
-    it, it starts from the set ``ph`` carries. ``log_level`` is passed to
-    MLPSSCHA, and from 1 the iterations are listed here as well.
-
-    """
-    if force_constants is not None:
-        ph = ph.replicate()
-        ph.force_constants = force_constants
-    sscha = MLPSSCHA(
-        ph,
-        mlp,
-        temperature=temperature,
-        number_of_snapshots=SNAPSHOTS,
-        max_iterations=ITERATIONS,
-        mesh=MESH,
-        random_seed=SEED,
-        log_level=log_level,
-    ).run()
-    history = sscha.history
-    if log_level:
-        report_iterations(history, transient)
-    return (
-        np.array([h.free_energy for h in history]),
-        np.array([h.free_energy_error for h in history]),
-        np.array([h.potential_energy for h in history]),
-        np.array([h.harmonic_potential_energy for h in history]),
-        sscha.supercell_energy / sscha.n_cell,
-    )
-
-
-def run_all(dataset, transient=DEFAULT_TRANSIENT, log_level=0):
-    """Run all and write it to file."""
-    points = dataset.grid_points
-    shape = (len(TEMPERATURES), len(points), ITERATIONS)
-    free_energies = np.zeros(shape)
-    errors = np.zeros(shape)
-    potential = np.zeros(shape)
-    harmonic_potential = np.zeros(shape)
-    reference = np.zeros(len(points))
-    for column, point in enumerate(points):
-        ph = point.to_phonopy()
-        mlp = PhonopyMLP().load(MLP.format(point.index + 1))
-        for row, temperature in enumerate(TEMPERATURES):
-            print(f"({point.index + 1:03d}, {temperature})", flush=True)
-            (
-                free_energies[row, column],
-                errors[row, column],
-                potential[row, column],
-                harmonic_potential[row, column],
-                reference[column],
-            ) = sscha_free_energy(
-                ph, mlp, float(temperature), transient=transient, log_level=log_level
-            )
-
-    write_sampled(
-        TEMPERATURES,
-        np.array([np.linalg.norm(p.cell.cell, axis=1) for p in points]),
-        (free_energies, errors, potential, harmonic_potential),
-        reference,
-        "sscha.hdf5",
-    )
-
-
-def run_one(dataset, grid_point, temperature, transient=DEFAULT_TRANSIENT, log_level=0):
     """Run one grid point at one temperature and write it to its own file.
 
     ``grid_point`` is numbered from 1, as the directories are. ``temperature``
@@ -1811,105 +1673,49 @@ def run_one(dataset, grid_point, temperature, transient=DEFAULT_TRANSIENT, log_l
     if not 1 <= grid_point <= len(dataset.grid_points):
         raise SystemExit(f"-g is 1 to {len(dataset.grid_points)}.")
     point = dataset.grid_points[grid_point - 1]
-    row = int(np.argmin(np.abs(TEMPERATURES - temperature)))
-    t = TEMPERATURES[row]
+    t = TEMPERATURES[int(np.argmin(np.abs(TEMPERATURES - temperature)))]
 
-    ph = point.to_phonopy()
-    mlp = PhonopyMLP().load(MLP.format(grid_point))
     print(f"({grid_point:03d}, {t})", flush=True)
-    *terms, reference = sscha_free_energy(
-        ph, mlp, float(t), transient=transient, log_level=log_level
+    sscha = MLPSSCHA(
+        point.to_phonopy(),
+        PhonopyMLP().load(MLP.format(grid_point)),
+        temperature=float(t),
+        number_of_snapshots=SNAPSHOTS,
+        max_iterations=ITERATIONS,
+        mesh=MESH,
+        random_seed=SEED,
+        log_level=log_level,
     )
+    run = sscha.run().to_sscha_run()
+    if log_level:
+        run.report(transient)
 
     filename = f"sscha-g{grid_point:03d}-t{t:g}K.hdf5"
-    write_sampled(
-        TEMPERATURES[[row]],
-        np.linalg.norm(point.cell.cell, axis=1)[None, :],
-        tuple(term[None, None, :] for term in terms),
-        np.array([reference]),
-        filename,
-    )
+    write_sscha_run_hdf5(run, filename)
     print(f"Wrote {filename}", flush=True)
 
 
 def assemble(
     dataset,
     transient=DEFAULT_TRANSIENT,
-    pattern="sscha*.hdf5",
+    pattern="sscha-g*K.hdf5",
     filename="fph.hdf5",
 ):
-    """Gather what the runs wrote, and average it over one transient.
-
-    The pattern takes the whole-grid sscha.hdf5 of run_all and the per-run
-    files of run_one alike. Each is placed by the lattice lengths and the
-    temperature it carries, not by its name; a gap stops the write, and so
-    does a grid point and temperature covered twice. The averages are taken
-    here from the iterations the files carry, so --transient covers the whole
-    grid at once and costs no sampling.
-
-    """
-    points = dataset.grid_points
-    lattice_lengths = np.array([np.linalg.norm(p.cell.cell, axis=1) for p in points])
+    """Gather what the runs wrote into the free energies the analysis reads."""
     paths = sorted(glob.glob(pattern))
     if not paths:
         raise SystemExit(f"No file matches {pattern}.")
-    parts = [read_sscha_iterations_hdf5(path) for path in paths]
-    counts = {part.n_iterations for part in parts}
-    if len(counts) > 1:
-        raise SystemExit(
-            f"The files hold {sorted(counts)} iterations. One array cannot "
-            "carry runs of different lengths, so gather them apart."
-        )
-    shape = (len(TEMPERATURES), len(points), counts.pop())
-    free_energies = np.full(shape, np.nan)
-    errors = np.full(shape, np.nan)
-    potential = np.full(shape, np.nan)
-    harmonic_potential = np.full(shape, np.nan)
-    reference = np.full(len(points), np.nan)
-
-    seen = set()
-    for path, part in zip(paths, parts):
-        for i, t in enumerate(part.temperatures):
-            row = int(np.argmin(np.abs(TEMPERATURES - t)))
-            for j, lengths in enumerate(part.lattice_lengths):
-                column = int(np.argmin(np.abs(lattice_lengths - lengths).sum(axis=1)))
-                if (row, column) in seen:
-                    raise SystemExit(
-                        f"{path} covers grid point {column + 1} at "
-                        f"{TEMPERATURES[row]:g} K, which another file covers "
-                        "as well. Gather one sweep at a time."
-                    )
-                seen.add((row, column))
-                free_energies[row, column] = part.free_energies[i, j]
-                errors[row, column] = part.errors[i, j]
-                potential[row, column] = part.potential_energies[i, j]
-                harmonic_potential[row, column] = part.harmonic_potential_energies[i, j]
-                reference[column] = part.reference_energies[j]
-
-    located = free_energies[:, :, 0]
-    missing = np.argwhere(np.isnan(located))
-    if len(missing) > 0:
-        first = ", ".join(
-            f"(grid {c + 1}, {TEMPERATURES[r]:g} K)" for r, c in missing[:5]
-        )
-        raise SystemExit(
-            f"{len(paths)} file(s) read, {len(missing)} of "
-            f"{located.size} values missing: {first} ..."
-        )
-
-    write_free_energies_hdf5(
-        SSCHAFreeEnergies(
+    points = dataset.grid_points
+    try:
+        free_energies = assemble_sscha_free_energies(
+            [read_sscha_run_hdf5(path) for path in paths],
             TEMPERATURES,
-            average(free_energies, transient),
-            errors=combine(errors, transient),
-            lattice_lengths=lattice_lengths,
-            reference_energies=reference,
-            potential_energies=average(potential, transient),
-            harmonic_potential_energies=average(harmonic_potential, transient),
-            transient_iterations=transient,
-        ),
-        filename,
-    )
+            np.array([np.linalg.norm(p.cell.cell, axis=1) for p in points]),
+            transient,
+        )
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    write_free_energies_hdf5(free_energies, filename)
     print(f"Wrote {filename} from {len(paths)} file(s)", flush=True)
 
 
@@ -1920,21 +1726,20 @@ def main():
         "-g",
         type=int,
         default=None,
-        help="grid point, numbered from 1 (default: all of them)",
+        help="grid point to run, numbered from 1",
     )
     parser.add_argument(
         "--temperature",
         "-t",
         type=float,
         default=None,
-        help="temperature in K; the nearest of TEMPERATURES is run "
-        "(default: all of them)",
+        help="temperature in K; the nearest of TEMPERATURES is run",
     )
     parser.add_argument(
         "--assemble",
         "-a",
         action="store_true",
-        help="gather the sscha*.hdf5 the runs wrote into fph.hdf5",
+        help="gather the sscha-g*K.hdf5 the runs wrote into fph.hdf5",
     )
     parser.add_argument(
         "--transient",
@@ -1955,14 +1760,12 @@ def main():
     dataset = read_aniso_qha_dataset(DATASET)
     if args.assemble:
         assemble(dataset, args.transient)
-    elif args.grid_point is None and args.temperature is None:
-        run_all(dataset, args.transient, args.verbose)
-    elif args.grid_point is not None and args.temperature is not None:
-        run_one(
+    elif args.grid_point is None or args.temperature is None:
+        raise SystemExit("Give -g and -t to run, or -a to gather.")
+    else:
+        run_sscha(
             dataset, args.grid_point, args.temperature, args.transient, args.verbose
         )
-    else:
-        raise SystemExit("-g and -t go together.")
 
 
 if __name__ == "__main__":

--- a/phonopy/qha/anisotropic.py
+++ b/phonopy/qha/anisotropic.py
@@ -330,10 +330,13 @@ class FreeEnergySurfaceFit:
 class AnisotropicQHAResult:
     """Immutable results of an anisotropic quasi-harmonic calculation.
 
-    Temperature-indexed arrays have the same length N, which is one less
-    than the number of input temperature points (the extra point is
-    consumed by the finite differences of the thermal expansions).
-    Quantities computed by central differences (thermal_expansion,
+    Temperature-indexed arrays have the same length N. With
+    lattice_smoothing="none" the thermal expansions are central
+    differences, which leave the highest input temperature without a
+    value, and N is one less than the number of input temperature points;
+    with a smoothing method the expansions are the analytic slope of the
+    fitted model and N is the number of input points. Quantities computed
+    by central differences (thermal_expansion,
     axial_thermal_expansions) carry a leading zero. Energies and volumes
     refer to the primitive cell, consistently with the phonon thermal
     properties, while the lattice parameters are the unit-cell
@@ -470,8 +473,9 @@ def run_anisotropic_qha(
     parameters a(T), b(T), c(T) and, by central differences, the axial
     thermal expansions.
 
-    Note that finite differences consume one temperature point: supply one
-    more point than the temperature range of interest.
+    Note that with lattice_smoothing="none" the central differences consume
+    one temperature point: supply one more point than the temperature range
+    of interest.
 
     Parameters
     ----------
@@ -614,13 +618,13 @@ def run_anisotropic_qha(
         pressure,
     )
 
-    m = len(temps_in)
+    n_temperatures = len(temps_in)
     n_points = len(phonopys)
-    helmholtz_lattice = np.zeros((m, n_points), dtype="double")
-    equilibrium_lattice_parameters = np.zeros((m, 3), dtype="double")
-    gibbs_free_energies = np.zeros(m, dtype="double")
-    surface_fit_rms = np.zeros(m, dtype="double")
-    minimum_extrapolated = np.zeros(m, dtype=bool)
+    helmholtz_lattice = np.zeros((n_temperatures, n_points), dtype="double")
+    equilibrium_lattice_parameters = np.zeros((n_temperatures, 3), dtype="double")
+    gibbs_free_energies = np.zeros(n_temperatures, dtype="double")
+    surface_fit_rms = np.zeros(n_temperatures, dtype="double")
+    minimum_extrapolated = np.zeros(n_temperatures, dtype=bool)
     surface_fit_rank = n_terms
 
     axis_labels = ("a", "b", "c")
@@ -640,7 +644,7 @@ def run_anisotropic_qha(
             hi = free_points[:, pos].max()
             print(f"Sampled range {axis_labels[col]}: [{lo:.6f}, {hi:.6f}] A")
 
-    for i in range(m):
+    for i in range(n_temperatures):
         fe = el[i]
         helmholtz_lattice[i] = fe
         fit = FreeEnergySurfaceFit(free_points, fe, degree=surface_degree)
@@ -685,41 +689,41 @@ def run_anisotropic_qha(
             n_terms=smoothing_terms,
         )
 
-    k = float((volumes / lattice_lengths.prod(axis=1)).mean())
-    equilibrium_volumes = k * equilibrium_lattice_parameters.prod(axis=1)
+    volume_ratio = float((volumes / lattice_lengths.prod(axis=1)).mean())
+    equilibrium_volumes = volume_ratio * equilibrium_lattice_parameters.prod(axis=1)
     if axial_slopes is None:
+        # The central differences leave the highest temperature without a
+        # value, so it is not returned.
         thermal_expansion = compute_volumetric_thermal_expansion(
             temps_in, equilibrium_volumes
         )
         axial_thermal_expansions = compute_axial_thermal_expansion(
             temps_in, equilibrium_lattice_parameters
         )
+        n_returned = n_temperatures - 1
     else:
         # The smoothed lattice parameters come from a model that is
         # differentiable in closed form, so its slope is taken directly
         # rather than approximated by differences of it. V is the product
         # of the three lengths, so beta is the sum of the axial terms.
-        axial_thermal_expansions = (
-            axial_slopes[: m - 1] / equilibrium_lattice_parameters[: m - 1]
-        )
+        axial_thermal_expansions = axial_slopes / equilibrium_lattice_parameters
         thermal_expansion = axial_thermal_expansions.sum(axis=1)
-
-    n = m - 1
+        n_returned = n_temperatures
     return AnisotropicQHAResult(
-        temperatures=temps_in[:n],
+        temperatures=temps_in[:n_returned],
         lattice_lengths=lattice_lengths,
         free_lattice_indices=np.array(free_indices, dtype="int64"),
         surface_degree=surface_degree,
-        helmholtz_lattice=helmholtz_lattice[:n],
-        equilibrium_lattice_parameters=equilibrium_lattice_parameters[:n],
-        equilibrium_volumes=equilibrium_volumes[:n],
-        gibbs_free_energies=gibbs_free_energies[:n],
+        helmholtz_lattice=helmholtz_lattice[:n_returned],
+        equilibrium_lattice_parameters=equilibrium_lattice_parameters[:n_returned],
+        equilibrium_volumes=equilibrium_volumes[:n_returned],
+        gibbs_free_energies=gibbs_free_energies[:n_returned],
         thermal_expansion=thermal_expansion,
         axial_thermal_expansions=axial_thermal_expansions,
-        surface_fit_rms=surface_fit_rms[:n],
+        surface_fit_rms=surface_fit_rms[:n_returned],
         surface_fit_rank=surface_fit_rank,
         surface_n_terms=n_terms,
-        minimum_extrapolated=minimum_extrapolated[:n],
+        minimum_extrapolated=minimum_extrapolated[:n_returned],
         mesh=mesh,
         primitive_volumes=volumes,
         lattice_smoothing=lattice_smoothing,

--- a/phonopy/qha/free_energy_io.py
+++ b/phonopy/qha/free_energy_io.py
@@ -10,24 +10,21 @@ PhononFreeEnergies or SSCHAFreeEnergies -- and each says in its own docstring
 what it carries. The file records the type that wrote it, and
 check_free_energies refuses one that does not belong to the run at hand.
 
-SSCHAIterations is the exception: it holds what an SSCHA sweep sampled,
-before any averaging, and is the free energy of nothing. The averaging reads
-it and writes SSCHAFreeEnergies. Handing it to the analysis is refused on its
-type, rather than averaged on the spot over iterations nobody chose.
-
 """
 
 from __future__ import annotations
 
 import dataclasses
 import os
-from typing import ClassVar
+from collections.abc import Sequence
+from typing import Any, ClassVar
 
 import h5py  # type: ignore[import-untyped]
 import numpy as np
 from numpy.typing import NDArray
 
 from phonopy import __version__
+from phonopy.sscha.run import SSCHARun
 
 
 @dataclasses.dataclass(frozen=True)
@@ -144,7 +141,7 @@ class SSCHAFreeEnergies(PhononFreeEnergies):
     transient_iterations : int, optional
         How many iterations at the start of each run were left out of the
         averages, or None. A count, not a position on the iteration axis.
-        The iterations themselves are in the SSCHAIterations the averaging
+        The iterations themselves are in the SSCHARun files the averaging
         read, so this is the record of what was taken from them.
 
     Notes
@@ -220,124 +217,32 @@ class SSCHAFreeEnergies(PhononFreeEnergies):
             )
 
 
-@dataclasses.dataclass(frozen=True)
-class SSCHAIterations:
-    """What an SSCHA sweep sampled, before any averaging.
-
-    The runs write this and the averaging reads it. It is the free energy of
-    nothing: every array carries an iteration axis, and which iterations to
-    average over is chosen afterwards. The averaging writes
-    SSCHAFreeEnergies, and that is what the analysis takes.
-
-    Attributes
-    ----------
-    temperatures : ndarray
-        Temperatures in K. shape=(temperatures,)
-    free_energies : ndarray
-        SSCHA free energy of each iteration, in eV per primitive cell.
-        shape=(temperatures, grid_points, iterations)
-    errors : ndarray
-        Statistical error of each iteration's free energy, in eV per
-        primitive cell. shape=(temperatures, grid_points, iterations)
-    potential_energies : ndarray
-        Ensemble average of the potential energy of each iteration, measured
-        from reference_energies, in eV per primitive cell.
-        shape=(temperatures, grid_points, iterations)
-    harmonic_potential_energies : ndarray
-        Ensemble average of the harmonic potential energy of each iteration's
-        own force constants, in eV per primitive cell.
-        shape=(temperatures, grid_points, iterations)
-    reference_energies : ndarray
-        The energy the free energies are measured from, in eV per primitive
-        cell. shape=(grid_points,)
-    lattice_lengths : ndarray, optional
-        Lattice-vector lengths (a, b, c) of the grid points in angstrom, or
-        None. Carried so that a reader can place each file on the grid.
-        shape=(grid_points, 3)
-
-    Notes
-    -----
-    The iteration axis holds the iterations of one run in the order they were
-    made, starting with the first one the run recorded. MLPSSCHA numbers and
-    logs those from 1, so index k on this axis is the run's iteration k + 1.
-    The transient is counted rather than pointed at, so it does not depend on
-    that numbering: 2 leaves out the first two iterations, whichever numbers
-    they carry.
-
-    """
-
-    ITERATION_RESOLVED: ClassVar[tuple[str, ...]] = (
-        "free_energies",
-        "errors",
-        "potential_energies",
-        "harmonic_potential_energies",
-    )
-
-    temperatures: NDArray[np.double]
-    free_energies: NDArray[np.double]
-    errors: NDArray[np.double]
-    potential_energies: NDArray[np.double]
-    harmonic_potential_energies: NDArray[np.double]
-    reference_energies: NDArray[np.double]
-    lattice_lengths: NDArray[np.double] | None = None
-
-    def __post_init__(self) -> None:
-        """Check the arrays against each other."""
-        shape = self.free_energies.shape
-        if len(shape) != 3 or shape[0] != len(self.temperatures):
-            raise ValueError(
-                "free_energies must have shape (temperatures, grid_points, "
-                f"iterations) with {len(self.temperatures)} rows, but has "
-                f"{shape}."
-            )
-        for name in self.ITERATION_RESOLVED:
-            values = getattr(self, name)
-            if values.shape != shape:
-                raise ValueError(
-                    f"{name} must have the shape of free_energies, {shape}, "
-                    f"but has {values.shape}."
-                )
-        if self.reference_energies.shape != (shape[1],):
-            raise ValueError(
-                "reference_energies is one value per grid point, so it must "
-                f"have shape {(shape[1],)}, but has "
-                f"{self.reference_energies.shape}."
-            )
-        lengths = self.lattice_lengths
-        if lengths is not None and lengths.shape != (shape[1], 3):
-            raise ValueError(
-                f"lattice_lengths must have shape {(shape[1], 3)}, "
-                f"but has {lengths.shape}."
-            )
-
-    @property
-    def n_grid_points(self) -> int:
-        """Return the number of grid points."""
-        return int(self.free_energies.shape[1])
-
-    @property
-    def n_iterations(self) -> int:
-        """Return the number of iterations each run made."""
-        return int(self.free_energies.shape[2])
-
-
-TYPES: dict[str, type] = {
+TYPES: dict[str, type[FreeEnergies]] = {
     cls.__name__: cls
-    for cls in (
-        ElectronicFreeEnergies,
-        PhononFreeEnergies,
-        SSCHAFreeEnergies,
-        SSCHAIterations,
-    )
+    for cls in (ElectronicFreeEnergies, PhononFreeEnergies, SSCHAFreeEnergies)
 }
 
 
-def _write_hdf5(stored, filename: str | os.PathLike) -> None:
-    """Write one of the types of this module, recording which it is."""
-    name = type(stored).__name__
+def write_free_energies_hdf5(
+    free_energies: FreeEnergies,
+    filename: str | os.PathLike = "free_energies.hdf5",
+) -> None:
+    """Write free energies over a temperature grid and a lattice grid.
+
+    Parameters
+    ----------
+    free_energies : FreeEnergies
+        One of the types of this module. The file records which, so that
+        reading it back as another term is refused rather than silent.
+    filename : str or os.PathLike, optional
+        Output file name.
+
+    """
+    name = type(free_energies).__name__
     if name not in TYPES:
-        raise ValueError(f"{name} is not one of {', '.join(TYPES)}.")
-    free_energies = stored
+        raise ValueError(
+            f"{name} is not one of the free energy types, {', '.join(TYPES)}."
+        )
 
     with h5py.File(filename, "w") as w:
         w.attrs["creator"] = "phonopy"
@@ -350,20 +255,26 @@ def _write_hdf5(stored, filename: str | os.PathLike) -> None:
                 w.create_dataset(field.name, data=values)
 
 
-def _read_hdf5(filename: str | os.PathLike):
-    """Read a file written by _write_hdf5, as the type that wrote it."""
+def read_free_energies_hdf5(
+    filename: str | os.PathLike = "free_energies.hdf5",
+) -> FreeEnergies:
+    """Read free energies written by write_free_energies_hdf5.
+
+    They come back as the type that wrote them.
+
+    """
     with h5py.File(filename, "r") as f:
         name = str(f.attrs["type"]) if "type" in f.attrs else ""
         if name not in TYPES:
             raise ValueError(
-                f"{filename} records the type {name!r}, which is not one of "
-                f"{', '.join(TYPES)}."
+                f"{filename} records the free energy type {name!r}, which is "
+                f"not one of {', '.join(TYPES)}."
             )
         cls = TYPES[name]
         # Only what the type declares, so a file written when it had a field
         # more is still read, ignoring that one.
         declared = {field.name for field in dataclasses.fields(cls)}
-        stored = {}
+        stored: dict[str, Any] = {}
         for key in f:
             if key not in declared:
                 continue
@@ -378,67 +289,93 @@ def _read_hdf5(filename: str | os.PathLike):
             raise ValueError(f"{filename} is a {name}, but {error}") from error
 
 
-def write_free_energies_hdf5(
-    free_energies: FreeEnergies,
-    filename: str | os.PathLike = "free_energies.hdf5",
-) -> None:
-    """Write free energies over a temperature grid and a lattice grid.
+def assemble_sscha_free_energies(
+    runs: Sequence[SSCHARun],
+    temperatures: NDArray[np.double],
+    lattice_lengths: NDArray[np.double],
+    transient: int = 1,
+) -> SSCHAFreeEnergies:
+    """Average a sweep's runs and place them on its grid.
+
+    Each run averages itself over the iterations after the transient, so
+    another transient costs no sampling: read the same runs and assemble them
+    again.
+
+    A run is placed by the temperature and the lattice lengths it carries
+    rather than by where it came from, so the order they are given in does
+    not matter. A grid point and temperature that no run covers stops the
+    assembly, and so does one that two runs cover.
 
     Parameters
     ----------
-    free_energies : FreeEnergies
-        One of the free energy types of this module. The file records which,
-        so that reading it back as another term is refused rather than silent.
-    filename : str or os.PathLike, optional
-        Output file name.
+    runs : Sequence[SSCHARun]
+        What the sweep sampled, one per grid point and temperature.
+    temperatures : ndarray
+        Temperatures of the grid in K. shape=(temperatures,)
+    lattice_lengths : ndarray
+        Lattice-vector lengths (a, b, c) of the grid points in angstrom.
+        shape=(grid_points, 3)
+    transient : int, optional
+        How many iterations at the start of each run to leave out of its
+        average. Default is 1, which drops the iteration that samples the
+        starting force constants. How many more belong to the transient
+        depends on the system; SSCHARun.report shows it.
 
     """
-    if not isinstance(free_energies, FreeEnergies):
+    shape = (len(temperatures), len(lattice_lengths))
+    free_energies = np.full(shape, np.nan)
+    errors = np.full(shape, np.nan)
+    potential = np.full(shape, np.nan)
+    harmonic_potential = np.full(shape, np.nan)
+    reference = np.full(shape[1], np.nan)
+
+    counts = {run.n_iterations for run in runs}
+    if len(counts) > 1:
         raise ValueError(
-            f"{type(free_energies).__name__} is not a free energy. "
-            "write_sscha_iterations_hdf5 writes what a sweep sampled."
+            f"The runs made {sorted(counts)} iterations. Averaging over "
+            "different numbers of them would weight the grid unevenly."
         )
-    _write_hdf5(free_energies, filename)
+    for run in runs:
+        if run.lattice_lengths is None:
+            raise ValueError(
+                "A run carries no lattice_lengths, so it cannot be placed on the grid."
+            )
+        row = int(np.argmin(np.abs(temperatures - run.temperature)))
+        column = int(
+            np.argmin(np.abs(lattice_lengths - run.lattice_lengths).sum(axis=1))
+        )
+        if not np.isnan(free_energies[row, column]):
+            raise ValueError(
+                f"Two runs cover grid point {column + 1} at {temperatures[row]:g} K."
+            )
+        (
+            free_energies[row, column],
+            errors[row, column],
+            potential[row, column],
+            harmonic_potential[row, column],
+        ) = run.averaged(transient)
+        reference[column] = run.reference_energy
 
-
-def read_free_energies_hdf5(
-    filename: str | os.PathLike = "free_energies.hdf5",
-) -> FreeEnergies:
-    """Read free energies written by write_free_energies_hdf5.
-
-    They come back as the type that wrote them.
-
-    """
-    stored = _read_hdf5(filename)
-    if not isinstance(stored, FreeEnergies):
+    missing = np.argwhere(np.isnan(free_energies))
+    if len(missing) > 0:
+        first = ", ".join(
+            f"(grid point {c + 1}, {temperatures[r]:g} K)" for r, c in missing[:5]
+        )
         raise ValueError(
-            f"{filename} holds {type(stored).__name__}, what a sweep sampled "
-            "rather than a free energy. Average it into free energies first."
+            f"{len(runs)} run(s) given, {len(missing)} of {free_energies.size} "
+            f"values missing: {first} ..."
         )
-    return stored
 
-
-def write_sscha_iterations_hdf5(
-    iterations: SSCHAIterations,
-    filename: str | os.PathLike = "sscha.hdf5",
-) -> None:
-    """Write what an SSCHA sweep sampled, before any averaging."""
-    if not isinstance(iterations, SSCHAIterations):
-        raise ValueError(f"{type(iterations).__name__} is not SSCHAIterations.")
-    _write_hdf5(iterations, filename)
-
-
-def read_sscha_iterations_hdf5(
-    filename: str | os.PathLike = "sscha.hdf5",
-) -> SSCHAIterations:
-    """Read what write_sscha_iterations_hdf5 wrote."""
-    stored = _read_hdf5(filename)
-    if not isinstance(stored, SSCHAIterations):
-        raise ValueError(
-            f"{filename} holds {type(stored).__name__}, which is already "
-            "averaged. The iterations are in the file the runs wrote."
-        )
-    return stored
+    return SSCHAFreeEnergies(
+        np.asarray(temperatures, dtype="double"),
+        free_energies,
+        errors=errors,
+        lattice_lengths=np.asarray(lattice_lengths, dtype="double"),
+        reference_energies=reference,
+        potential_energies=potential,
+        harmonic_potential_energies=harmonic_potential,
+        transient_iterations=transient,
+    )
 
 
 def _temperature_index(

--- a/phonopy/sscha/core.py
+++ b/phonopy/sscha/core.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
@@ -15,6 +16,7 @@ from phonopy import Phonopy
 from phonopy.harmonic.force_constants import compact_fc_to_full_fc
 from phonopy.interface.mlp import PhonopyMLP
 from phonopy.physical_units import get_physical_units
+from phonopy.sscha.run import SSCHARun, write_sscha_run_hdf5
 
 
 @dataclass(frozen=True)
@@ -456,6 +458,32 @@ class MLPSSCHA:
             if self._log_level:
                 print("")
         return self
+
+    def to_sscha_run(self) -> SSCHARun:
+        """Return what this run sampled, one value per iteration.
+
+        Every iteration is kept and none is averaged, so that which of them
+        to average over is chosen afterwards rather than here.
+
+        """
+        history = self.history
+        if not history:
+            raise RuntimeError("The run has no iteration to report yet.")
+        return SSCHARun(
+            temperature=self.temperature,
+            free_energies=np.array([h.free_energy for h in history]),
+            errors=np.array([h.free_energy_error for h in history]),
+            potential_energies=np.array([h.potential_energy for h in history]),
+            harmonic_potential_energies=np.array(
+                [h.harmonic_potential_energy for h in history]
+            ),
+            reference_energy=self.supercell_energy / self.n_cell,
+            lattice_lengths=np.linalg.norm(self._ph.unitcell.cell, axis=1),
+        )
+
+    def write_hdf5(self, filename: str | os.PathLike = "sscha.hdf5") -> None:
+        """Write what this run sampled to an hdf5 file."""
+        write_sscha_run_hdf5(self.to_sscha_run(), filename)
 
     def __iter__(self) -> MLPSSCHA:
         """Iterate over force constants calculations."""

--- a/phonopy/sscha/run.py
+++ b/phonopy/sscha/run.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Read and write what one SSCHA run sampled.
+
+A run reports one free energy per iteration, and which of them to average is
+chosen afterwards. The file therefore holds every iteration and no average,
+so that another choice costs no sampling. The averages, over a grid of runs,
+are phonopy.qha.free_energy_io's SSCHAFreeEnergies.
+
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from typing import Any, NamedTuple
+
+import h5py  # type: ignore[import-untyped]
+import numpy as np
+from numpy.typing import NDArray
+
+from phonopy import __version__
+
+TYPE = "SSCHARun"
+
+
+class SSCHAAverage(NamedTuple):
+    """One run's estimate, over the iterations after its transient."""
+
+    free_energy: float
+    error: float
+    potential_energy: float
+    harmonic_potential_energy: float
+
+
+@dataclasses.dataclass(frozen=True)
+class SSCHARun:
+    """What one SSCHA run sampled, before any averaging.
+
+    Attributes
+    ----------
+    temperature : float
+        Temperature of the run in K.
+    free_energies : ndarray
+        SSCHA free energy of each iteration, in eV per primitive cell.
+        shape=(iterations,)
+    errors : ndarray
+        Statistical error of each iteration's free energy, in eV per
+        primitive cell. shape=(iterations,)
+    potential_energies : ndarray
+        Ensemble average of the potential energy of each iteration, measured
+        from reference_energy, in eV per primitive cell.
+        shape=(iterations,)
+    harmonic_potential_energies : ndarray
+        Ensemble average of the harmonic potential energy of each iteration's
+        own force constants, in eV per primitive cell. shape=(iterations,)
+    reference_energy : float
+        The energy the free energies are measured from, in eV per primitive
+        cell: the supercell without displacements over the primitive cells in
+        it.
+    lattice_lengths : ndarray, optional
+        Lattice-vector lengths (a, b, c) of the run's cell in angstrom, or
+        None. Carried so that a sweep can place the run on its grid.
+        shape=(3,)
+
+    Notes
+    -----
+    The iteration axis holds the iterations in the order they were made,
+    starting with the first one the run recorded. MLPSSCHA numbers and logs
+    those from 1, so index k on this axis is iteration k + 1.
+
+    The first iterations start from force constants that are not yet
+    self-consistent, and how many of them to leave out of an average is a
+    property of the run rather than of this file, so nothing here records it.
+    SSCHAFreeEnergies records the choice that was made from these.
+
+    """
+
+    PER_ITERATION = (
+        "free_energies",
+        "errors",
+        "potential_energies",
+        "harmonic_potential_energies",
+    )
+
+    temperature: float
+    free_energies: NDArray[np.double]
+    errors: NDArray[np.double]
+    potential_energies: NDArray[np.double]
+    harmonic_potential_energies: NDArray[np.double]
+    reference_energy: float
+    lattice_lengths: NDArray[np.double] | None = None
+
+    def __post_init__(self) -> None:
+        """Check the arrays against each other."""
+        shape = self.free_energies.shape
+        if len(shape) != 1:
+            raise ValueError(
+                f"free_energies is one value per iteration, so it must have "
+                f"shape (iterations,), but has {shape}."
+            )
+        for name in self.PER_ITERATION:
+            values = getattr(self, name)
+            if values.shape != shape:
+                raise ValueError(
+                    f"{name} must have the shape of free_energies, {shape}, "
+                    f"but has {values.shape}."
+                )
+        lengths = self.lattice_lengths
+        if lengths is not None and lengths.shape != (3,):
+            raise ValueError(
+                f"lattice_lengths must have shape (3,), but has {lengths.shape}."
+            )
+
+    @property
+    def n_iterations(self) -> int:
+        """Return the number of iterations the run made."""
+        return int(self.free_energies.shape[0])
+
+    def _kept(self, transient: int) -> slice:
+        """Return the iterations left once the transient is taken off."""
+        if not 0 <= transient < self.n_iterations:
+            raise ValueError(
+                f"transient is {transient}, and the run made "
+                f"{self.n_iterations} iterations."
+            )
+        return slice(transient, None)
+
+    def averaged(self, transient: int = 1) -> SSCHAAverage:
+        """Return the estimate over the iterations after the transient.
+
+        The free energy and the two ensemble averages are means of the kept
+        iterations. Those are independent draws, so the error of their mean
+        adds theirs in quadrature, sqrt(sum(e**2))/n, rather than averaging
+        them: n iterations are sqrt(n) more precise than one.
+
+        """
+        kept = self._kept(transient)
+        errors = self.errors[kept]
+        return SSCHAAverage(
+            float(self.free_energies[kept].mean()),
+            float(np.sqrt(np.square(errors).sum()) / errors.size),
+            float(self.potential_energies[kept].mean()),
+            float(self.harmonic_potential_energies[kept].mean()),
+        )
+
+    def departures(self, transient: int = 1) -> NDArray[np.double]:
+        """Return how far each iteration sits from the mean of the kept ones.
+
+        In units of that iteration's own error, so the reading is the same
+        whatever the system. An iteration past the transient scatters about
+        the fixed point by about its own error and gives about 1; a larger
+        value means the iteration was still approaching that point.
+
+        Every iteration is returned, the transient included, since seeing
+        where it ends is what the number is for. shape=(iterations,)
+
+        """
+        mean = self.free_energies[self._kept(transient)].mean()
+        return (self.free_energies - mean) / self.errors
+
+    def report(self, transient: int = 1) -> None:
+        """List the iterations, their errors and their departures, in meV."""
+        z = self.departures(transient)
+        kept = self._kept(transient)
+        print("  iter       F [meV]   error [meV]   (F - mean)/error", flush=True)
+        for i, (f, e, d) in enumerate(
+            zip(self.free_energies, self.errors, z, strict=True)
+        ):
+            mark = "*" if i < transient else " "
+            print(
+                f"  {i + 1:4d}{mark} {f * 1e3:12.4f} {e * 1e3:13.4f} {d:+18.1f}",
+                flush=True,
+            )
+        worst = int(np.argmax(np.abs(z[kept]))) + transient
+        print(
+            f"  * left out as the transient. Of the kept iterations the "
+            f"furthest from the mean is {worst + 1}, at {abs(z[worst]):.1f} sigma.",
+            flush=True,
+        )
+        print(
+            "  A kept iteration far outside the scatter of the rest is still "
+            "in the transient: raise the transient and look again.",
+            flush=True,
+        )
+
+
+def write_sscha_run_hdf5(
+    run: SSCHARun, filename: str | os.PathLike = "sscha.hdf5"
+) -> None:
+    """Write what one SSCHA run sampled.
+
+    The file records its type, so that reading it as a free energy is refused
+    rather than silent.
+
+    """
+    if not isinstance(run, SSCHARun):
+        raise ValueError(f"{type(run).__name__} is not an {TYPE}.")
+    with h5py.File(filename, "w") as w:
+        w.attrs["creator"] = "phonopy"
+        w.attrs["phonopy_version"] = __version__
+        w.attrs["type"] = TYPE
+        w.attrs["unit"] = "eV/primitive_cell"
+        for field in dataclasses.fields(run):
+            values = getattr(run, field.name)
+            if values is not None:
+                w.create_dataset(field.name, data=values)
+
+
+def read_sscha_run_hdf5(filename: str | os.PathLike = "sscha.hdf5") -> SSCHARun:
+    """Read what write_sscha_run_hdf5 wrote."""
+    with h5py.File(filename, "r") as f:
+        name = str(f.attrs["type"]) if "type" in f.attrs else ""
+        if name != TYPE:
+            raise ValueError(
+                f"{filename} records the type {name!r}, not {TYPE}. The "
+                "averages of a grid of runs are read with "
+                "read_free_energies_hdf5."
+            )
+        declared = {field.name for field in dataclasses.fields(SSCHARun)}
+        stored: dict[str, Any] = {}
+        for key in f:
+            if key not in declared:
+                continue
+            # temperature and reference_energy are stored as scalar datasets.
+            if f[key].shape == ():
+                stored[key] = float(f[key][()])
+            else:
+                stored[key] = np.array(f[key][:], dtype="double")
+        try:
+            return SSCHARun(**stored)
+        except TypeError as error:
+            raise ValueError(f"{filename} is an {TYPE}, but {error}") from error

--- a/test/qha/test_anisotropic.py
+++ b/test/qha/test_anisotropic.py
@@ -420,7 +420,9 @@ def test_run_anisotropic_precomputed_needs_no_force_constants(
         phonon_free_energies=fe_phonon_ev,
         surface_degree=2,
     )
-    assert result.equilibrium_lattice_parameters.shape == (len(TEMPERATURES) - 1, 3)
+    # phonon_free_energies switches the smoothing on, whose analytic slope
+    # keeps every temperature.
+    assert result.equilibrium_lattice_parameters.shape == (len(TEMPERATURES), 3)
 
 
 def _electronic_free_energies(n_temperatures: int, n_points: int) -> NDArray[np.double]:
@@ -711,6 +713,9 @@ def test_run_anisotropic_qha_passes_gamma_center(ph_nacl: Phonopy) -> None:
         internal_energies=energies,
         phonon_free_energies=fe_phonon / get_physical_units().EvTokJmol,
         surface_degree=2,
+        # The mesh path above smooths nothing, and only smoothing decides
+        # whether the highest temperature is returned.
+        lattice_smoothing="none",
     )
     np.testing.assert_allclose(
         result.helmholtz_lattice, reference.helmholtz_lattice, rtol=1e-12, atol=0.0
@@ -789,6 +794,11 @@ def test_run_anisotropic_smoothing_uses_the_analytic_slope(ph_nacl: Phonopy) -> 
 
     assert raw.lattice_smoothing == "none"
     assert smoothed.lattice_smoothing == "einstein"
+    # The central differences leave the highest temperature without a value,
+    # while the analytic slope has one there.
+    assert raw.temperatures.shape == (len(TEMPERATURES) - 1,)
+    assert smoothed.temperatures.shape == (len(TEMPERATURES),)
+    assert smoothed.axial_thermal_expansions.shape == (len(TEMPERATURES), 3)
     np.testing.assert_allclose(
         smoothed.thermal_expansion,
         smoothed.axial_thermal_expansions.sum(axis=1),

--- a/test/qha/test_anisotropic_qha_cli.py
+++ b/test/qha/test_anisotropic_qha_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import pathlib
 
 import numpy as np
@@ -405,109 +406,128 @@ def test_free_energy_terms_round_trip(tmp_path: pathlib.Path) -> None:
         np.testing.assert_allclose(getattr(read, name), terms[name])
 
 
-def _sampled(temperatures: NDArray[np.double], iterations: int = 6) -> dict:
-    """Return what a sweep sampled: every term with an iteration axis."""
+def _sweep(temperatures, lengths, iterations=6):
+    """Return one SSCHARun per grid point and temperature."""
+    from phonopy.sscha.run import SSCHARun
+
     rng = np.random.default_rng(0)
-    terms = _decomposed(temperatures)
-    shape = terms["free_energies"].shape + (iterations,)
-    sampled = {
-        "temperatures": temperatures,
-        "reference_energies": terms["reference_energies"],
-        "errors": rng.uniform(1e-6, 1e-5, shape),
-    }
-    for name in ("free_energies", "potential_energies", "harmonic_potential_energies"):
-        sampled[name] = terms[name][:, :, None] + rng.normal(0.0, 1e-4, shape)
-    return sampled
+    runs = []
+    for column, cell in enumerate(lengths):
+        for t in temperatures:
+
+            def series(base):
+                v = base + rng.normal(0.0, 1e-5, iterations)
+                v[0] += 5e-4  # a transient first iteration
+                return v
+
+            runs.append(
+                SSCHARun(
+                    temperature=float(t),
+                    free_energies=series(0.1 + 0.001 * column - 1e-5 * t),
+                    errors=rng.uniform(1e-6, 1e-5, iterations),
+                    potential_energies=series(0.2),
+                    harmonic_potential_energies=series(0.15),
+                    reference_energy=-40.0 - column,
+                    lattice_lengths=np.array(cell),
+                )
+            )
+    return runs
 
 
-def test_sscha_iterations_round_trip(tmp_path: pathlib.Path) -> None:
-    """What a sweep sampled survives a write and read, as its own type.
+def test_assemble_sscha_free_energies() -> None:
+    """The runs are placed by what they carry, and each averages itself.
 
-    It is kept so that the averaging can be run again over another set of
-    iterations without sampling again.
+    Another transient is a second assembly of the same runs, so it costs no
+    sampling; the file records which one it was.
 
     """
-    from phonopy.qha.free_energy_io import (
-        SSCHAIterations,
-        read_sscha_iterations_hdf5,
-        write_sscha_iterations_hdf5,
-    )
+    from phonopy.qha.free_energy_io import assemble_sscha_free_energies
 
-    sampled = _sampled(np.arange(0.0, 101.0, 10.0))
+    temperatures = np.arange(0.0, 31.0, 10.0)
     lengths = np.array([[3.0, 3.0, 5.0], [3.1, 3.1, 5.1], [3.2, 3.2, 5.2]])
-    path = tmp_path / "sscha.hdf5"
-    write_sscha_iterations_hdf5(
-        SSCHAIterations(lattice_lengths=lengths, **sampled), path
+    runs = _sweep(temperatures, lengths)
+
+    fe = assemble_sscha_free_energies(runs, temperatures, lengths, transient=1)
+    assert fe.free_energies.shape == (4, 3)
+    assert fe.transient_iterations == 1
+    np.testing.assert_allclose(fe.lattice_lengths, lengths)
+
+    # Placement is by content, so the order given does not matter.
+    shuffled = assemble_sscha_free_energies(
+        runs[::-1], temperatures, lengths, transient=1
     )
+    np.testing.assert_allclose(shuffled.free_energies, fe.free_energies)
 
-    back = read_sscha_iterations_hdf5(path)
-    assert isinstance(back, SSCHAIterations)
-    assert back.n_grid_points == 3
-    assert back.n_iterations == 6
-    for name, values in sampled.items():
-        np.testing.assert_allclose(getattr(back, name), values)
+    # Each entry is that run's own average and combined error.
+    run = runs[0]
+    row = int(np.argmin(np.abs(temperatures - run.temperature)))
+    column = int(np.argmin(np.abs(lengths - run.lattice_lengths).sum(axis=1)))
+    average = run.averaged(1)
+    assert fe.free_energies[row, column] == pytest.approx(average.free_energy)
+    assert fe.errors[row, column] == pytest.approx(average.error)
+
+    # A second transient moves the values without touching the runs.
+    other = assemble_sscha_free_energies(runs, temperatures, lengths, transient=2)
+    assert other.transient_iterations == 2
+    assert not np.allclose(other.free_energies, fe.free_energies)
 
 
-def test_sscha_iterations_are_not_free_energies(tmp_path: pathlib.Path) -> None:
-    """The two files are different types, and neither is read as the other.
+def test_assemble_sscha_free_energies_refuses_a_gap_and_a_clash() -> None:
+    """A grid point no run covers stops the assembly, and so does a double."""
+    from phonopy.qha.free_energy_io import assemble_sscha_free_energies
 
-    The analysis takes SSCHAFreeEnergies. Reading a sweep's own file as one
-    would average it over iterations nobody chose, so the read refuses.
+    temperatures = np.arange(0.0, 31.0, 10.0)
+    lengths = np.array([[3.0, 3.0, 5.0], [3.1, 3.1, 5.1], [3.2, 3.2, 5.2]])
+    runs = _sweep(temperatures, lengths)
+
+    with pytest.raises(ValueError, match="values missing"):
+        assemble_sscha_free_energies(runs[:-1], temperatures, lengths)
+    with pytest.raises(ValueError, match="Two runs cover"):
+        assemble_sscha_free_energies(runs + runs[:1], temperatures, lengths)
+    short = dataclasses.replace(
+        runs[0],
+        free_energies=runs[0].free_energies[:4],
+        errors=runs[0].errors[:4],
+        potential_energies=runs[0].potential_energies[:4],
+        harmonic_potential_energies=runs[0].harmonic_potential_energies[:4],
+    )
+    with pytest.raises(ValueError, match="iterations. Averaging over"):
+        assemble_sscha_free_energies([short] + runs[1:], temperatures, lengths)
+
+
+def test_transient_iterations_is_kept_as_a_label(tmp_path: pathlib.Path) -> None:
+    """The averaged file records which iterations it was taken from.
+
+    The iterations themselves are in the SSCHARun files the averaging read,
+    so nothing here can check the count; it travels with the averages so that
+    two of these files can be compared knowing how each was taken.
 
     """
     from phonopy.qha.free_energy_io import (
         SSCHAFreeEnergies,
-        SSCHAIterations,
         read_free_energies_hdf5,
-        read_sscha_iterations_hdf5,
         write_free_energies_hdf5,
-        write_sscha_iterations_hdf5,
     )
 
     temperatures = np.arange(0.0, 101.0, 10.0)
-    sampled = _sampled(temperatures)
-    lengths = np.array([[3.0, 3.0, 5.0], [3.1, 3.1, 5.1], [3.2, 3.2, 5.2]])
-    sweep = tmp_path / "sscha.hdf5"
-    write_sscha_iterations_hdf5(
-        SSCHAIterations(lattice_lengths=lengths, **sampled), sweep
-    )
-    with pytest.raises(ValueError, match="rather than a free energy"):
-        read_free_energies_hdf5(sweep)
-
     terms = _decomposed(temperatures)
-    averaged = tmp_path / "fph.hdf5"
+    lengths = np.array([[3.0, 3.0, 5.0], [3.1, 3.1, 5.1], [3.2, 3.2, 5.2]])
+    path = tmp_path / "fph.hdf5"
     write_free_energies_hdf5(
         SSCHAFreeEnergies(
             temperatures, lattice_lengths=lengths, transient_iterations=2, **terms
         ),
-        averaged,
+        path,
     )
-    with pytest.raises(ValueError, match="already"):
-        read_sscha_iterations_hdf5(averaged)
-
-    # The averaged file records what was taken, and holds no iterations.
-    back = read_free_energies_hdf5(averaged)
+    back = read_free_energies_hdf5(path)
     assert back.transient_iterations == 2
-    assert not hasattr(back, "iteration_free_energies")
+    assert isinstance(back.transient_iterations, int)
 
-
-def test_sscha_iterations_shapes_are_checked() -> None:
-    """Every term needs the iteration axis, and the grid has to line up."""
-    from phonopy.qha.free_energy_io import SSCHAIterations
-
-    sampled = _sampled(np.arange(0.0, 101.0, 10.0))
-    SSCHAIterations(**sampled)
-
-    with pytest.raises(ValueError, match="free_energies must have shape"):
-        SSCHAIterations(
-            **{**sampled, "free_energies": sampled["free_energies"][:, :, 0]}
-        )
-    with pytest.raises(ValueError, match="errors must have the shape"):
-        SSCHAIterations(**{**sampled, "errors": sampled["errors"][:, :, :3]})
-    with pytest.raises(ValueError, match="reference_energies is one value"):
-        SSCHAIterations(**{**sampled, "reference_energies": np.zeros(2)})
-    with pytest.raises(ValueError, match="lattice_lengths must have shape"):
-        SSCHAIterations(lattice_lengths=np.zeros((2, 3)), **sampled)
+    # It is optional, and absent means the file does not say.
+    write_free_energies_hdf5(
+        SSCHAFreeEnergies(temperatures, lattice_lengths=lengths, **terms), path
+    )
+    assert read_free_energies_hdf5(path).transient_iterations is None
 
 
 def test_free_energy_terms_are_checked() -> None:

--- a/test/sscha/test_run.py
+++ b/test/sscha/test_run.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Tests for what one SSCHA run sampled."""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from phonopy.sscha.run import SSCHARun, read_sscha_run_hdf5, write_sscha_run_hdf5
+
+
+def _run(iterations: int = 6) -> SSCHARun:
+    """Return a run with distinguishable values in every field."""
+    rng = np.random.default_rng(0)
+    return SSCHARun(
+        temperature=250.0,
+        free_energies=0.1 + rng.normal(0.0, 1e-4, iterations),
+        errors=rng.uniform(1e-6, 1e-5, iterations),
+        potential_energies=0.2 + rng.normal(0.0, 1e-4, iterations),
+        harmonic_potential_energies=0.15 + rng.normal(0.0, 1e-4, iterations),
+        reference_energy=-23.4,
+        lattice_lengths=np.array([4.56, 4.56, 2.818]),
+    )
+
+
+def test_sscha_run_round_trip(tmp_path: pathlib.Path) -> None:
+    """A run survives a write and a read, with its scalars still scalars."""
+    pytest.importorskip("h5py")
+    run = _run()
+    path = tmp_path / "sscha.hdf5"
+    write_sscha_run_hdf5(run, path)
+
+    back = read_sscha_run_hdf5(path)
+    assert isinstance(back, SSCHARun)
+    assert back.temperature == 250.0
+    assert isinstance(back.temperature, float)
+    assert back.reference_energy == pytest.approx(-23.4)
+    assert back.n_iterations == 6
+    for name in SSCHARun.PER_ITERATION:
+        np.testing.assert_allclose(getattr(back, name), getattr(run, name))
+    np.testing.assert_allclose(back.lattice_lengths, run.lattice_lengths)
+
+
+def test_sscha_run_is_not_a_free_energy(tmp_path: pathlib.Path) -> None:
+    """Neither file is read as the other.
+
+    The analysis takes free energies. Reading a run as one would average it
+    over iterations nobody chose, so each reader refuses the other's file.
+
+    """
+    pytest.importorskip("h5py")
+    from phonopy.qha.free_energy_io import (
+        PhononFreeEnergies,
+        read_free_energies_hdf5,
+        write_free_energies_hdf5,
+    )
+
+    sampled = tmp_path / "sscha.hdf5"
+    write_sscha_run_hdf5(_run(), sampled)
+    with pytest.raises(ValueError, match="free energy type 'SSCHARun'"):
+        read_free_energies_hdf5(sampled)
+
+    averaged = tmp_path / "fph.hdf5"
+    write_free_energies_hdf5(
+        PhononFreeEnergies(np.arange(0.0, 31.0, 10.0), np.zeros((4, 2))), averaged
+    )
+    with pytest.raises(ValueError, match="not SSCHARun"):
+        read_sscha_run_hdf5(averaged)
+
+
+def test_sscha_run_shapes_are_checked() -> None:
+    """Every term needs the iteration axis, and the cell has three lengths."""
+    run = _run()
+    fields = {
+        name: getattr(run, name)
+        for name in ("temperature", "reference_energy", *SSCHARun.PER_ITERATION)
+    }
+    SSCHARun(**fields)
+
+    with pytest.raises(ValueError, match="free_energies is one value per"):
+        SSCHARun(**{**fields, "free_energies": run.free_energies[:, None]})
+    with pytest.raises(ValueError, match="errors must have the shape"):
+        SSCHARun(**{**fields, "errors": run.errors[:3]})
+    with pytest.raises(ValueError, match="lattice_lengths must have shape"):
+        SSCHARun(lattice_lengths=np.zeros(2), **fields)


### PR DESCRIPTION
#971 was reverted by #972 accidentally. This restores it and adds `phonopy/sscha/run.py` with its tests, that were forgotten in the previous commit.