### PR TITLE
Add QHA system entropy and enthalpy at constant pressure

### DIFF
--- a/doc/migration-v5.md
+++ b/doc/migration-v5.md
@@ -140,6 +140,8 @@ lattice-parameter output.
 | `PhonopyQHA(volumes, ...)`   | `run_qha(phonopys, ...)` (`QHAResult`)     |
 | `volume_temperature`         | `QHAResult.equilibrium_volumes`            |
 | `gibbs_temperature`          | `QHAResult.gibbs_free_energies`            |
+| `entropy_temperature`        | `QHAResult.entropy_temperature`            |
+| `enthalpy_temperature`       | `QHAResult.enthalpy_temperature`           |
 | `bulk_modulus_temperature`   | `QHAResult.bulk_moduli`                    |
 | `thermal_expansion`          | `QHAResult.thermal_expansion`              |
 | `heat_capacity_P_polyfit`    | `QHAResult.heat_capacity_P.heat_capacities`|

--- a/doc/qha.md
+++ b/doc/qha.md
@@ -324,6 +324,16 @@ Remarks:
   `result.heat_capacity_P.heat_capacities`. The
   {math}`-T\partial^2 G/\partial T^2` variant of the legacy API is not
   provided.
+- System entropy and enthalpy at constant pressure are
+  `result.entropy_temperature` (J/K/mol) and
+  `result.enthalpy_temperature` (eV). They are obtained from a
+  degree-4 polynomial fit of {math}`S(V)` evaluated at {math}`V_eq(T,p)`,
+  not from a numerical derivative of {math}`G(T)`. Then
+  {math}`H = G + TS`. The deprecated `PhonopyQHA` exposes the same
+  quantities as `entropy_temperature` and `enthalpy_temperature`; those
+  properties are unavailable when temperature-dependent electronic
+  free-energy arrays are supplied, because {math}`S_\mathrm{el}` is not
+  stored on that path.
 - The file formats written by `phonopy.qha.output` are identical to those of
   `phonopy-qha` for the shared quantities.
 
@@ -481,6 +491,8 @@ is:
 | ---------------------------- | ------------------------------------------ |
 | `volume_temperature`         | `QHAResult.equilibrium_volumes`            |
 | `gibbs_temperature`          | `QHAResult.gibbs_free_energies`            |
+| `entropy_temperature`        | `QHAResult.entropy_temperature`            |
+| `enthalpy_temperature`       | `QHAResult.enthalpy_temperature`           |
 | `bulk_modulus_temperature`   | `QHAResult.bulk_moduli`                    |
 | `thermal_expansion`          | `QHAResult.thermal_expansion`              |
 | `heat_capacity_P_polyfit`    | `QHAResult.heat_capacity_P.heat_capacities`|

--- a/phonopy/api_qha.py
+++ b/phonopy/api_qha.py
@@ -187,6 +187,32 @@ class PhonopyQHA:
         return self._qha.gibbs_temperature
 
     @property
+    def entropy_temperature(self) -> NDArray[np.double]:
+        """Return entropy of the system at temperatures.
+
+        Returns
+        -------
+        ndarray
+            Entropy at constant pressure and temperatures in J/K/mol.
+            shape=(temperatures, ), dtype=float
+
+        """
+        return self._qha.entropy_temperature
+
+    @property
+    def enthalpy_temperature(self) -> NDArray[np.double]:
+        """Return enthalpy of the system at temperatures.
+
+        Returns
+        -------
+        ndarray
+            Enthalpy at constant pressure and temperatures in eV.
+            shape=(temperatures, ), dtype=float
+
+        """
+        return self._qha.enthalpy_temperature
+
+    @property
     def bulk_modulus_temperature(self) -> NDArray[np.double]:
         """Return bulk modulus at temperatures.
 
@@ -299,6 +325,18 @@ class PhonopyQHA:
     ) -> None:
         """Write Gibbs free energy vs temperature in file."""
         self._qha.write_gibbs_temperature(filename=filename)
+
+    def write_entropy_temperature(
+        self, filename: str | os.PathLike = "entropy-temperature.dat"
+    ) -> None:
+        """Write entropy vs temperature in file."""
+        self._qha.write_entropy_temperature(filename=filename)
+
+    def write_enthalpy_temperature(
+        self, filename: str | os.PathLike = "enthalpy-temperature.dat"
+    ) -> None:
+        """Write enthalpy vs temperature in file."""
+        self._qha.write_enthalpy_temperature(filename=filename)
 
     def write_bulk_modulus_temperature(
         self, filename: str | os.PathLike = "bulk_modulus-temperature.dat"

--- a/phonopy/qha/calc.py
+++ b/phonopy/qha/calc.py
@@ -88,6 +88,74 @@ def compute_heat_capacity_p_numerical(
     return np.array(cp, dtype="double")
 
 
+class EntropyEnthalpyArrays(NamedTuple):
+    """System entropy and enthalpy at constant pressure.
+
+    Both arrays have the same length as the input temperatures. Entropy is
+    in J/K/mol and enthalpy is in eV, so that G = H - T S holds after
+    converting S to eV/K.
+
+    """
+
+    entropy: NDArray[np.double]
+    enthalpy: NDArray[np.double]
+
+
+def compute_entropy_enthalpy_temperature(
+    temperatures: NDArray[np.double],
+    volumes: NDArray[np.double],
+    equilibrium_volumes: NDArray[np.double],
+    entropy: NDArray[np.double],
+    gibbs_free_energies: NDArray[np.double],
+) -> EntropyEnthalpyArrays:
+    """Evaluate S(T, p) and H(T, p) from S(V) fits at V_eq.
+
+    S(T, p) = S(T, V_eq(T, p)) where S(V) is a degree-4 polynomial at each
+    temperature, the same interpolation used for heat_capacity_P_polyfit.
+    G(T) is not differentiated. H = G + T S with S converted eV/K.
+
+    Parameters
+    ----------
+    temperatures : ndarray
+        Temperatures in K. shape=(num_elems,)
+    volumes : ndarray
+        Unit cell volumes of the input volume grid in angstrom^3.
+        shape=(volumes,)
+    equilibrium_volumes : ndarray
+        Equilibrium volumes at temperatures in angstrom^3.
+        shape=(num_elems,)
+    entropy : ndarray
+        Entropies at constant volume in J/K/mol, indexed consistently
+        with temperatures. shape=(>=num_elems, volumes)
+    gibbs_free_energies : ndarray
+        Gibbs free energies at temperatures in eV. shape=(num_elems,)
+
+    """
+    if len(volumes) < 5:
+        raise RuntimeError(
+            "At least 5 volume points are needed to fit S(V) to a "
+            "polynomial of degree 4."
+        )
+
+    ev_to_jmol = get_physical_units().EvTokJmol * 1000.0
+    n = len(temperatures)
+    entropies = np.empty(n, dtype="double")
+    for i in range(n):
+        try:
+            parameters = np.polyfit(volumes, entropy[i], 4)
+        except np.lib.polynomial.RankWarning as exc:  # type: ignore
+            msg = ["Failed to fit entropies to polynomial of degree 4."]
+            msg += ["At least 5 volume points are needed for the fitting."]
+            raise RuntimeError("\n".join(msg)) from exc
+        entropies[i] = float(np.polyval(parameters, equilibrium_volumes[i]))
+
+    enthalpies = gibbs_free_energies + temperatures * entropies / ev_to_jmol
+    return EntropyEnthalpyArrays(
+        entropy=np.array(entropies, dtype="double"),
+        enthalpy=np.array(enthalpies, dtype="double"),
+    )
+
+
 def compute_heat_capacity_p_polyfit(
     temperatures: NDArray[np.double],
     volumes: NDArray[np.double],

--- a/phonopy/qha/core.py
+++ b/phonopy/qha/core.py
@@ -12,6 +12,7 @@ from numpy.typing import NDArray
 
 from phonopy.physical_units import get_physical_units
 from phonopy.qha.calc import (
+    compute_entropy_enthalpy_temperature,
     compute_gruneisen_parameters,
     compute_heat_capacity_p_numerical,
     compute_heat_capacity_p_polyfit,
@@ -256,6 +257,8 @@ class QHA:
         self._volume_entropy: list[NDArray[np.double]] | None = None
         self._volume_cv: list[NDArray[np.double]] | None = None
         self._cp_polyfit: NDArray[np.double] | None = None
+        self._equiv_entropies: NDArray[np.double] | None = None
+        self._equiv_enthalpies: NDArray[np.double] | None = None
         self._dsdv: NDArray[np.double] | None = None
         self._gruneisen_parameters: NDArray[np.double] | None = None
         self._len: int | None = None
@@ -287,6 +290,49 @@ class QHA:
         if self._equiv_energies is None:
             raise RuntimeError("Run QHA.run() to compute Gibbs free energies.")
         return self._equiv_energies[: self._len]
+
+    @property
+    def entropy_temperature(self) -> NDArray[np.double]:
+        """Return entropy of the system at constant pressure and temperatures.
+
+        S(T, p) = S(T, V_eq(T, p)) from a degree-4 polynomial fit of S(V)
+        at each temperature, the same interpolation used for
+        heat_capacity_P_polyfit. G(T) is not differentiated.
+
+        Returns
+        -------
+        ndarray
+            Entropy at constant pressure in J/K/mol.
+            shape=(temperatures,)
+
+        """
+        if self._equiv_entropies is None:
+            raise RuntimeError(
+                "Entropy is unavailable. Run QHA.run(); note it is not "
+                "supported with temperature dependent electronic energies."
+            )
+        return self._equiv_entropies[: self._len]
+
+    @property
+    def enthalpy_temperature(self) -> NDArray[np.double]:
+        """Return enthalpy of the system at constant pressure and temperatures.
+
+        H(T, p) = G(T, p) + T S(T, p). G is the EOS-fit minimum
+        (gibbs_temperature) and is not differentiated.
+
+        Returns
+        -------
+        ndarray
+            Enthalpy at constant pressure in eV.
+            shape=(temperatures,)
+
+        """
+        if self._equiv_enthalpies is None:
+            raise RuntimeError(
+                "Enthalpy is unavailable. Run QHA.run(); note it is not "
+                "supported with temperature dependent electronic energies."
+            )
+        return self._equiv_enthalpies[: self._len]
 
     @property
     def bulk_modulus_temperature(self) -> NDArray[np.double]:
@@ -408,6 +454,7 @@ class QHA:
         self._set_thermal_expansion()
         self._set_heat_capacity_P_numerical()
         self._set_heat_capacity_P_polyfit()
+        self._set_entropy_and_enthalpy()
         self._set_gruneisen_parameter()  # To be run after thermal expansion.
 
         assert self._thermal_expansions is not None
@@ -726,6 +773,44 @@ class QHA:
                 w.write(
                     "%20.15f %25.15f\n"
                     % (self._temperatures[i], self._equiv_energies[i])
+                )
+
+    def get_entropy_temperature(self) -> NDArray[np.double]:
+        """Return entropy of the system at temperatures."""
+        return self.entropy_temperature
+
+    def write_entropy_temperature(
+        self, filename: str | os.PathLike = "entropy-temperature.dat"
+    ) -> None:
+        """Write entropy vs temperature in file."""
+        assert self._temperatures is not None
+        assert self._equiv_entropies is not None
+        assert self._len is not None
+
+        with open(filename, "w") as w:
+            for i in range(self._len):
+                w.write(
+                    "%20.15f %25.15f\n"
+                    % (self._temperatures[i], self._equiv_entropies[i])
+                )
+
+    def get_enthalpy_temperature(self) -> NDArray[np.double]:
+        """Return enthalpy of the system at temperatures."""
+        return self.enthalpy_temperature
+
+    def write_enthalpy_temperature(
+        self, filename: str | os.PathLike = "enthalpy-temperature.dat"
+    ) -> None:
+        """Write enthalpy vs temperature in file."""
+        assert self._temperatures is not None
+        assert self._equiv_enthalpies is not None
+        assert self._len is not None
+
+        with open(filename, "w") as w:
+            for i in range(self._len):
+                w.write(
+                    "%20.15f %25.15f\n"
+                    % (self._temperatures[i], self._equiv_enthalpies[i])
                 )
 
     def get_bulk_modulus_temperature(self) -> NDArray[np.double]:
@@ -1241,6 +1326,29 @@ class QHA:
             np.array([self._volumes, self._entropy[j]]).T
             for j in range(1, self._num_elems - 1)
         ]
+
+    def _set_entropy_and_enthalpy(self) -> None:
+        assert self._temperatures is not None
+        assert self._equiv_volumes is not None
+        assert self._equiv_energies is not None
+        assert self._entropy is not None
+
+        # S_el = -(dF_el/dT)_V is not stored on this path, so S and H
+        # from volume combinations are only exact for static U(V).
+        if self._electronic_energies.ndim != 1:
+            self._equiv_entropies = None
+            self._equiv_enthalpies = None
+            return
+
+        result = compute_entropy_enthalpy_temperature(
+            self._temperatures,
+            self._volumes,
+            self._equiv_volumes,
+            self._entropy,
+            self._equiv_energies,
+        )
+        self._equiv_entropies = result.entropy
+        self._equiv_enthalpies = result.enthalpy
 
     def _set_gruneisen_parameter(self) -> None:
         assert self._equiv_volumes is not None

--- a/phonopy/qha/output.py
+++ b/phonopy/qha/output.py
@@ -137,6 +137,24 @@ def write_gibbs_temperature(
             w.write("%20.15f %25.15f\n" % (t, g))
 
 
+def write_entropy_temperature(
+    result: QHAResult, filename: str | os.PathLike = "entropy-temperature.dat"
+) -> None:
+    """Write entropy vs temperature in file."""
+    with open(filename, "w") as w:
+        for t, s in zip(result.temperatures, result.entropy_temperature, strict=True):
+            w.write("%20.15f %25.15f\n" % (t, s))
+
+
+def write_enthalpy_temperature(
+    result: QHAResult, filename: str | os.PathLike = "enthalpy-temperature.dat"
+) -> None:
+    """Write enthalpy vs temperature in file."""
+    with open(filename, "w") as w:
+        for t, h in zip(result.temperatures, result.enthalpy_temperature, strict=True):
+            w.write("%20.15f %25.15f\n" % (t, h))
+
+
 def write_bulk_modulus_temperature(
     result: QHAResult, filename: str | os.PathLike = "bulk_modulus-temperature.dat"
 ) -> None:

--- a/phonopy/qha/qha.py
+++ b/phonopy/qha/qha.py
@@ -21,6 +21,7 @@ from numpy.typing import NDArray
 
 from phonopy.physical_units import get_physical_units
 from phonopy.qha.calc import (
+    compute_entropy_enthalpy_temperature,
     compute_gruneisen_parameters,
     compute_heat_capacity_p_polyfit,
     compute_volumetric_thermal_expansion,
@@ -133,6 +134,12 @@ class QHAResult:
         Equilibrium volumes V_0 at temperatures in angstrom^3. shape=(N,)
     gibbs_free_energies : ndarray
         Gibbs free energies at temperatures in eV. shape=(N,)
+    entropy_temperature : ndarray
+        System entropy at constant pressure in J/K/mol, S(T, V_eq(T, p))
+        from a degree-4 S(V) fit. shape=(N,)
+    enthalpy_temperature : ndarray
+        System enthalpy at constant pressure in eV, H = G + T S.
+        shape=(N,)
     bulk_moduli : ndarray
         Bulk moduli at temperatures in GPa. shape=(N,)
     thermal_expansion : ndarray
@@ -156,6 +163,8 @@ class QHAResult:
     eos_parameters: NDArray[np.double]
     equilibrium_volumes: NDArray[np.double]
     gibbs_free_energies: NDArray[np.double]
+    entropy_temperature: NDArray[np.double]
+    enthalpy_temperature: NDArray[np.double]
     bulk_moduli: NDArray[np.double]
     thermal_expansion: NDArray[np.double]
     gruneisen_parameters: NDArray[np.double]
@@ -295,6 +304,9 @@ def run_qha(
     heat_capacity_P = _make_heat_capacity_data(
         temps, volumes, equilibrium_volumes, cv_kept, entropy_kept
     )
+    entropy_enthalpy = compute_entropy_enthalpy_temperature(
+        temps, volumes, equilibrium_volumes, entropy_kept, gibbs_free_energies
+    )
 
     n = len(temps) - 1
     lattice: QHALatticeData | None = None
@@ -318,6 +330,8 @@ def run_qha(
         eos_parameters=eos_parameters[:n],
         equilibrium_volumes=equilibrium_volumes[:n],
         gibbs_free_energies=gibbs_free_energies[:n],
+        entropy_temperature=entropy_enthalpy.entropy[:n],
+        enthalpy_temperature=entropy_enthalpy.enthalpy[:n],
         bulk_moduli=bulk_moduli[:n],
         thermal_expansion=thermal_expansion,
         gruneisen_parameters=gruneisen_parameters,

--- a/test/qha/test_QHA.py
+++ b/test/qha/test_QHA.py
@@ -10,6 +10,7 @@ import pytest
 from numpy.typing import NDArray
 
 from phonopy import PhonopyQHA
+from phonopy.physical_units import get_physical_units
 
 current_dir = Path(__file__).resolve().parent
 
@@ -407,6 +408,34 @@ def test_write_gibbs_temperature(qha_si: PhonopyQHA, tmp_path: Path) -> None:
     np.testing.assert_allclose(data[:, 1], qha_si.gibbs_temperature, atol=1e-10)
 
 
+def test_write_entropy_temperature(qha_si: PhonopyQHA, tmp_path: Path) -> None:
+    """Test write_entropy_temperature."""
+    fn = tmp_path / "entropy-temperature.dat"
+    qha_si.write_entropy_temperature(filename=fn)
+    data = np.loadtxt(fn)
+    np.testing.assert_allclose(data[:, 1], qha_si.entropy_temperature, atol=1e-10)
+
+
+def test_write_enthalpy_temperature(qha_si: PhonopyQHA, tmp_path: Path) -> None:
+    """Test write_enthalpy_temperature."""
+    fn = tmp_path / "enthalpy-temperature.dat"
+    qha_si.write_enthalpy_temperature(filename=fn)
+    data = np.loadtxt(fn)
+    np.testing.assert_allclose(data[:, 1], qha_si.enthalpy_temperature, atol=1e-10)
+
+
+def test_enthalpy_equals_g_plus_ts(qha_si: PhonopyQHA) -> None:
+    """H = G + T S with S converted from J/K/mol to eV/K."""
+    ev_to_jmol = get_physical_units().EvTokJmol * 1000.0
+    t = temperatures_Si[: len(qha_si.gibbs_temperature)]
+    np.testing.assert_allclose(
+        qha_si.enthalpy_temperature,
+        qha_si.gibbs_temperature + t * qha_si.entropy_temperature / ev_to_jmol,
+        rtol=0,
+        atol=1e-12,
+    )
+
+
 def test_write_bulk_modulus_temperature(qha_si: PhonopyQHA, tmp_path: Path) -> None:
     """Test write_bulk_modulus_temperature."""
     fn = tmp_path / "bulk_modulus-temperature.dat"
@@ -459,6 +488,8 @@ def test_qha_plot_units(qha_si: PhonopyQHA) -> None:
     plt.close("all")
 
     assert "eV" in PhonopyQHA.gibbs_temperature.__doc__
+    assert "J/K/mol" in PhonopyQHA.entropy_temperature.__doc__
+    assert "eV" in PhonopyQHA.enthalpy_temperature.__doc__
     assert "GPa" in PhonopyQHA.bulk_modulus_temperature.__doc__
 
 

--- a/test/qha/test_entropy_enthalpy.py
+++ b/test/qha/test_entropy_enthalpy.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Tests for S(T, p) and H(T, p) from S(V) fits at V_eq."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phonopy.physical_units import get_physical_units
+from phonopy.qha.calc import compute_entropy_enthalpy_temperature
+
+
+def test_polyfit_recovers_exact_quadratic_entropy() -> None:
+    """A degree-2 S(V) is recovered exactly by the degree-4 fit."""
+    volumes = np.array([10.0, 11.0, 12.0, 13.0, 14.0], dtype="double")
+    temperatures = np.array([0.0, 100.0, 300.0], dtype="double")
+    v_eq = np.array([12.3, 12.4, 12.6], dtype="double")
+
+    def s_of_v(v: np.ndarray) -> np.ndarray:
+        return 3.0 + 0.5 * v + 0.01 * v**2
+
+    entropy = np.vstack([s_of_v(volumes), s_of_v(volumes), s_of_v(volumes)])
+    gibbs = np.array([-1.0, -1.2, -1.8], dtype="double")
+
+    result = compute_entropy_enthalpy_temperature(
+        temperatures, volumes, v_eq, entropy, gibbs
+    )
+    expected_s = s_of_v(v_eq)
+    ev_to_jmol = get_physical_units().EvTokJmol * 1000.0
+    expected_h = gibbs + temperatures * expected_s / ev_to_jmol
+
+    np.testing.assert_allclose(result.entropy, expected_s, rtol=0, atol=1e-12)
+    np.testing.assert_allclose(result.enthalpy, expected_h, rtol=0, atol=1e-12)
+
+
+def test_fewer_than_five_volumes_is_refused() -> None:
+    """Degree-4 S(V) fit needs at least five volume points."""
+    volumes = np.array([10.0, 11.0, 12.0, 13.0], dtype="double")
+    temperatures = np.array([100.0, 200.0], dtype="double")
+    entropy = np.ones((2, 4), dtype="double")
+    gibbs = np.zeros(2, dtype="double")
+    with pytest.raises(RuntimeError, match="At least 5 volume points"):
+        compute_entropy_enthalpy_temperature(
+            temperatures, volumes, volumes[:2], entropy, gibbs
+        )

--- a/test/qha/test_qha_output.py
+++ b/test/qha/test_qha_output.py
@@ -19,6 +19,8 @@ SIMPLE_WRITER_NAMES = [
     "write_volume_temperature",
     "write_thermal_expansion",
     "write_gibbs_temperature",
+    "write_entropy_temperature",
+    "write_enthalpy_temperature",
     "write_bulk_modulus_temperature",
     "write_gruneisen_temperature",
 ]

--- a/test/qha/test_run_qha.py
+++ b/test/qha/test_run_qha.py
@@ -18,6 +18,7 @@ from qha_utils import (
 )
 
 from phonopy import Phonopy, PhonopyQHA, run_qha
+from phonopy.physical_units import get_physical_units
 from phonopy.qha.electron import ElectronicStates, compute_free_energy_and_entropy
 from phonopy.qha.lattice import LatticeParametersFit
 from phonopy.qha.qha import QHAResult
@@ -75,6 +76,12 @@ def test_run_qha_matches_phonopy_qha(
     )
     np.testing.assert_allclose(
         result.gibbs_free_energies, ref.gibbs_temperature, rtol=0, atol=1e-12
+    )
+    np.testing.assert_allclose(
+        result.entropy_temperature, ref.entropy_temperature, rtol=0, atol=1e-12
+    )
+    np.testing.assert_allclose(
+        result.enthalpy_temperature, ref.enthalpy_temperature, rtol=0, atol=1e-12
     )
     np.testing.assert_allclose(
         result.bulk_moduli, ref.bulk_modulus_temperature, rtol=0, atol=1e-12
@@ -261,6 +268,18 @@ def test_run_qha_electronic_structures(nacl_qha_phonopys: list[Phonopy]) -> None
     )
     np.testing.assert_allclose(
         result.gibbs_free_energies, ref.gibbs_temperature, rtol=0, atol=1e-12
+    )
+    # Legacy PhonopyQHA does not store S_el, so S and H from V-combinations
+    # are refused there. run_qha already added S_el to the entropy grid.
+    with pytest.raises(RuntimeError, match="temperature dependent"):
+        _ = ref.entropy_temperature
+    ev_to_jmol = get_physical_units().EvTokJmol * 1000.0
+    np.testing.assert_allclose(
+        result.enthalpy_temperature,
+        result.gibbs_free_energies
+        + result.temperatures * result.entropy_temperature / ev_to_jmol,
+        rtol=0,
+        atol=1e-12,
     )
 
     cp_new = result.heat_capacity_P.heat_capacities


### PR DESCRIPTION
## Summary

Closes #889.

`PhonopyQHA` already returns `gibbs_temperature` = G(T, p). This adds the matching system (not phonon-only) values

- `entropy_temperature` in J/K/mol
- `enthalpy_temperature` in eV

and the same fields on `QHAResult` from `run_qha`.

S is **not** obtained from a numerical (−dG/dT)_p. Following the comment on #889, S(T, p) = S(T, V_eq(T, p)) using the same degree-4 S(V) polynomial already used by `heat_capacity_P_polyfit`. Then H = G + TS (S converted eV/K so the identity holds in the same units as G).

On the deprecated `PhonopyQHA` path this is refused when temperature-dependent electronic free-energy arrays are supplied, because S_el is not stored there. `run_qha(..., electronic_structures=...)` already adds S_el to the entropy grid, so the new `QHAResult` fields include the electronic contribution.

Writers: `write_entropy_temperature` / `write_enthalpy_temperature` (legacy class and `phonopy.qha.output`).

## Checks

- Exact quadratic S(V) is recovered by the degree-4 fit (`test_entropy_enthalpy.py`).
- H = G + TS holds to 1e-12 eV on the Si QHA fixture.
- `run_qha` and `PhonopyQHA` agree bitwise on NaCl (with and without p = 5 GPa).
- Spot-check only (not a CI bound): on Si, max relative |S − (−dG/dT)| is 2.7×10⁻³ for T > 100 K (10 K grid). That residual is the reason the implementation follows S(V_eq) rather than differentiating G.

This is a thermodynamic-API completion, not a materials discovery.

## Test plan

- [x] `pytest test/qha/test_entropy_enthalpy.py test/qha/test_QHA.py test/qha/test_QHA_efe.py test/qha/test_qha_output.py test/qha/test_run_qha.py::test_run_qha_matches_phonopy_qha test/qha/test_run_qha.py::test_run_qha_electronic_structures`
- [x] ruff on the touched files

Made with [Cursor](https://cursor.com)